### PR TITLE
Fix `add-to-cart` event not being sent to pixel-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bump `vtex.pixel-manager` major to `1.x`.
 
 ## [0.1.0] - 2019-11-18
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,11 +17,9 @@
     "vtex.order-items": "0.x",
     "vtex.checkout-resources": "0.x",
     "vtex.product-context": "0.x",
-    "vtex.pixel-manager": "0.x"
+    "vtex.pixel-manager": "1.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What does this PR do?

Fix `add-to-cart` event not being sent to pixel-manager, caused by the fact that the `push()` function that was coming from `usePixel()` would just be an empty function that returned `undefined`.

Turns out the major version of `vtex.pixel-manager` was wrong.

#### How to test it?

1. Go to: [Workspace](https://addtocartpixelevent--storecomponents.myvtex.com/)
2. Add an item to the cart
3. Open Chrome DevTools (or Firefox, if you're into that) and print `window.pixelManager` out to the console.
4. Check that the last event was an `add-to-cart` one.
