### PR TITLE
Add A2HS Prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A2HS prompt.
 
 ## [0.1.1] - 2019-11-21
 ### Fixed
@@ -13,4 +15,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.0] - 2019-11-18
 ### Added
-- Intial release.
+- Initial release.
+

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "vtex.order-items": "0.x",
     "vtex.checkout-resources": "0.x",
     "vtex.product-context": "0.x",
-    "vtex.pixel-manager": "1.x"
+    "vtex.pixel-manager": "1.x",
+    "vtex.store-resources": "0.x"
   },
   "registries": [
     "smartcheckout"

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -94,7 +94,7 @@ const AddToCartButton: FC<Props & InjectedIntlProps> = ({
   const dispatch = useProductDispatch()
   const { rootPath } = useRuntime()
   const { push } = usePixel()
-  const { settings = {}, showInstallPrompt } = usePWA()
+  const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings
   const translateMessage = (message: FormattedMessage.MessageDescriptor) =>
     intl.formatMessage(message)

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -13,6 +13,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import { addToCart as ADD_TO_CART } from 'vtex.checkout-resources/Mutations'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
+import { usePWA } from 'vtex.store-resources/PWAContext'
 
 import { compareObjects } from './modules/compareObjects'
 import { MapCatalogItemToCartReturn } from './modules/catalogItemToCart'
@@ -93,6 +94,8 @@ const AddToCartButton: FC<Props & InjectedIntlProps> = ({
   const dispatch = useProductDispatch()
   const { rootPath } = useRuntime()
   const { push } = usePixel()
+  const { settings = {}, showInstallPrompt } = usePWA()
+  const { promptOnCustomEvent } = settings
   const translateMessage = (message: FormattedMessage.MessageDescriptor) =>
     intl.formatMessage(message)
 
@@ -168,6 +171,11 @@ const AddToCartButton: FC<Props & InjectedIntlProps> = ({
     }
 
     toastMessage({ success: true, isNewItem: true })
+
+    /* PWA */
+    if (promptOnCustomEvent === 'addToCart' && showInstallPrompt) {
+      showInstallPrompt()
+    }
   }
 
   const handleClick = (e: React.MouseEvent) => {

--- a/react/package.json
+++ b/react/package.json
@@ -23,7 +23,7 @@
     "eslint-config-vtex-react": "^5.1.0",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "typescript": "3.5.2",
+    "typescript": "3.7.3",
     "vtex.checkout-resources": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.checkout-resources@0.11.0/public/_types/react",
     "vtex.css-handles": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles",
     "vtex.order-items": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.order-items@0.5.0/public/@types/vtex.order-items",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5477,10 +5477,10 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What does this PR do? \*
Enable to show `add to home screen` prompt on the first item added to cart based on PWA settings. *This is an old feature that I'm redoing*

![Screenshot from 2019-12-17 14-35-00](https://user-images.githubusercontent.com/6867958/71019971-27beda80-20da-11ea-86c7-75f58d2ca551.png)

#### How to test it? \*
[workspace](https://thay2--storecomponents.myvtex.com/)

1. Add an item to the cart
2. Check if the prompt shows

**Obs:** This happens only once.
