### PR TITLE
Set default value for rootPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `oneClickBuyLink` prop not working when `useRuntime()` did not return a `rootPath`.
 
 ## [0.2.2] - 2020-01-06
 ### Changed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -105,7 +105,7 @@ const AddToCartButton: FC<Props & InjectedIntlProps> = ({
     loading,
   }: OrderFormContext = OrderForm.useOrderForm()
   const dispatch = useProductDispatch()
-  const { rootPath } = useRuntime()
+  const { rootPath = '' } = useRuntime()
   const { push } = usePixel()
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings


### PR DESCRIPTION
#### What does this PR do? \*

This sets the default value for the `rootPath` variable to an empty string. This fixes the issue that arises when `useRuntime()` does not return a `rootPath`, in which case the path in line 185 becomes `undefined${oneClickBuyLink}` instead of simply `${oneClickBuyLink}`.

#### How to test it? \*

Visit [this workspace](https://rootpath--gc-jqu0734.myvtex.com/jogger-feminina-saruel/p). Click "Adicionar ao carrinho". You should be taken to `/cart`.

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
