### PR TITLE
Use render-runtime's navigate function to proceed to cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `render-runtime`'s `navigate` function to proceed to cart if the new checkout is installed in order to benefit from apollo cache.
 
 ## [0.2.3] - 2020-01-08
 ### Fixed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -186,7 +186,10 @@ const AddToCartButton: FC<Props & InjectedIntlProps> = ({
     })
 
     if (isOneClickBuy) {
-      if (major > 0 && !customOneClickBuyLink) {
+      if (
+        major > 0 &&
+        (!customOneClickBuyLink || customOneClickBuyLink === checkoutURL)
+      ) {
         navigate({ to: checkoutURL })
       } else {
         location.assign(rootPath + (customOneClickBuyLink || checkoutURL))

--- a/react/typings/vtex.checkout-resources.ts
+++ b/react/typings/vtex.checkout-resources.ts
@@ -1,1 +1,2 @@
 declare module 'vtex.checkout-resources/Mutations'
+declare module 'vtex.checkout-resources/Utils'

--- a/react/typings/vtex.store-resources.ts
+++ b/react/typings/vtex.store-resources.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.store-resources/PWAContext'


### PR DESCRIPTION
#### What does this PR do? \*

This PR implements the use of `render-runtime` `navigate` function to proceed to the new checkout cart. This is required to benefit from the apollo cache and thus not making unnecessary requests to the API.

#### How to test it? \*

- Proceed to the [workspace](https://proceedtocart--checkoutio.myvtex.com/)
- Add an item to cart
- Check if this action redirects you to the new cart
- Also check that the loading skeleton doesn't appear, since it's using the cache.

#### Describe alternatives you've considered, if any. \*

If the new checkout is not installed or if a custom one click buy link was provided, it redirects using the old way.

You can test it [here](https://proceedtocart--storecomponents.myvtex.com/)

<!--- Optional -->

#### Related to / Depends on \*

n/a

<!--- Optional -->
