### PR TITLE
Add new fields 'detailUrl' and 'imageUrl' to 'addToCart' event

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true,
   "eslint.validate": [
     {
       "language": "javascript",
@@ -31,5 +30,8 @@
       "directory": "node",
       "changeProcessCWD": true
     }
-  ]
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New fields `detailUrl` and `imageUrl` to items in `addToCart`.
 
 ## [0.3.0] - 2020-01-13
 ### Changed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -87,6 +87,8 @@ const adjustSkuItemForPixelEvent = (skuItem: MapCatalogItemToCartReturn) => {
     productRefId: skuItem.productRefId,
     brand: skuItem.brand,
     category,
+    detailUrl: skuItem.detailUrl,
+    imageUrl: skuItem.imageUrl,
   }
 }
 


### PR DESCRIPTION
#### What does this PR do? \*

Add new fields 'detailUrl' and 'imageUrl' to 'addToCart' event.

#### How to test it? \*

1. Open: https://brenonew--storecomponents.myvtex.com/
2. Add an item to cart
3. Check the console

#### Describe alternatives you've considered, if any. \*

none

#### Related to / Depends on \*

Related to https://github.com/vtex-apps/minicart/pull/202
