### PR TITLE
Send marketingData to orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Information regarding `marketingData` to parameters being passed upon calling `addToCart` so that the `OrderForm` can update itself to include `utm` and `utmi` information.
 
 ## [0.5.0] - 2020-02-20
 ### Changed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -15,6 +15,7 @@ import { usePWA } from 'vtex.store-resources/PWAContext'
 import { useOrderItems } from 'vtex.order-items/OrderItems'
 
 import { CartItem } from './modules/catalogItemToCart'
+import useMarketingSessionParams from './hooks/useMarketingSessionParams'
 
 interface Props {
   isOneClickBuy: boolean
@@ -74,6 +75,7 @@ const AddToCartButton: FC<Props> = ({
   const { push } = usePixel()
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings
+  const { utmParams, utmiParams } = useMarketingSessionParams()
   const translateMessage = (message: MessageDescriptor) =>
     intl.formatMessage(message)
 
@@ -107,7 +109,10 @@ const AddToCartButton: FC<Props> = ({
     event.stopPropagation()
     event.preventDefault()
 
-    const itemsAdded = addItem(skuItems)
+    const itemsAdded = addItem({
+      items: skuItems,
+      marketingData: { ...utmParams, ...utmiParams },
+    })
 
     const pixelEventItems = skuItems.map(adjustSkuItemForPixelEvent)
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -109,11 +109,7 @@ const AddToCartButton: FC<Props> = ({
     event.stopPropagation()
     event.preventDefault()
 
-    const itemsAdded = addItem({
-      items: skuItems,
-      marketingData: { ...utmParams, ...utmiParams },
-    })
-
+    const itemsAdded = addItem(skuItems, { ...utmParams, ...utmiParams })
     const pixelEventItems = skuItems.map(adjustSkuItemForPixelEvent)
 
     push({

--- a/react/hooks/useMarketingSessionParams.ts
+++ b/react/hooks/useMarketingSessionParams.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+
+type PublicSessionField =
+  | 'utm_source'
+  | 'utm_medium'
+  | 'utm_campaign'
+  | 'utmi_cp'
+  | 'utmi_p'
+  | 'utmi_pc'
+
+interface SessionPromiseFieldValue {
+  value: string
+}
+
+interface UtmParams {
+  utmSource?: string
+  utmMedium?: string
+  utmCampaign?: string
+}
+
+interface UtmiParams {
+  utmiCampaign?: string
+  utmiPage?: string
+  utmiPart?: string
+}
+
+interface SessionPromiseResponse {
+  id: string
+  namespaces: {
+    account: {
+      id: SessionPromiseFieldValue & { keepAlive: boolean }
+      accountName: SessionPromiseFieldValue
+    }
+    store: {
+      channel: SessionPromiseFieldValue
+      countryCode: SessionPromiseFieldValue
+      cultureInfo: SessionPromiseFieldValue
+      currencyCode: SessionPromiseFieldValue
+      currencySymbol: SessionPromiseFieldValue
+      admin_cultureInfo: SessionPromiseFieldValue
+    }
+    public: Record<PublicSessionField, SessionPromiseFieldValue>
+    creditControl: Record<string, SessionPromiseFieldValue>
+    authentication: Record<string, any>
+    profile: {
+      isAuthenticated: SessionPromiseFieldValue
+    }
+  }
+}
+
+const getUtmParams = (
+  publicFields: Record<PublicSessionField, SessionPromiseFieldValue>
+) => ({
+  utmSource: publicFields.utm_source.value,
+  utmMedium: publicFields.utm_medium.value,
+  utmCampaign: publicFields.utm_campaign.value,
+})
+
+const getUtmiParams = (
+  publicFields: Record<PublicSessionField, SessionPromiseFieldValue>
+) => ({
+  utmiPage: publicFields.utmi_p.value,
+  utmiPart: publicFields.utmi_pc.value,
+  utmiCampaign: publicFields.utmi_cp.value,
+})
+
+const getSessionPromiseFromWindow = () => {
+  const runtimeSessionPromise = (window as Window & {
+    ['__RENDER_8_SESSION__']?: {
+      sessionPromise?: Promise<SessionPromiseResponse>
+    }
+  }).__RENDER_8_SESSION__?.sessionPromise
+
+  return runtimeSessionPromise
+}
+
+const useMarketingSessionParams = () => {
+  const [utmParams, setUtmParams] = useState<UtmParams>({})
+  const [utmiParams, setUtmiParams] = useState<UtmiParams>({})
+
+  useEffect(() => {
+    async function updateMarketingData() {
+      const data = await getSessionPromiseFromWindow()
+
+      const publicFields = data?.namespaces.public ?? {}
+
+      if (Object.keys(publicFields).length === 0) {
+        return
+      }
+
+      setUtmParams(
+        getUtmParams(
+          publicFields as Record<PublicSessionField, SessionPromiseFieldValue>
+        )
+      )
+      setUtmiParams(
+        getUtmiParams(
+          publicFields as Record<PublicSessionField, SessionPromiseFieldValue>
+        )
+      )
+    }
+
+    updateMarketingData()
+  }, [])
+
+  return { utmParams, utmiParams }
+}
+
+export default useMarketingSessionParams


### PR DESCRIPTION
#### What does this PR do?

Enables the `add-to-cart-button` to send information regarding `marketingData` to the `addToCart` mutation so that the `orderForm` can update itself.

#### How to test it?

Go to this [Workspace](https://marketingdata--storecomponents.myvtex.com/gorgeous-watch/p?utm_source=welcome10), where there is a 50% discount associated with `utm_source=welcome10` for this watch. Add it to the cart and go to checkout. Check that its value is $220.00, instead of $440.00.

Also, in the Network tab of Chrome DevTools you can see that the `OrderForm` in the `checkout` has the following property:

![Screen Shot 2020-03-04 at 14 59 05](https://user-images.githubusercontent.com/27777263/75908333-b2d18600-5e28-11ea-9279-b7b47245e568.png)

#### Related to / Depends on

Should be merged after 

- https://github.com/vtex-apps/order-items/pull/17
- https://github.com/vtex/checkout-graphql/pull/48
- https://github.com/vtex-apps/checkout-resources/pull/32
