### PR TITLE
Add referenceId to addToCart event payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `referenceId` to `addToCart` event payload.
 
 ## [0.7.0] - 2020-03-20
 ### Added

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -61,6 +61,7 @@ const adjustSkuItemForPixelEvent = (skuItem: CartItem) => {
     category,
     detailUrl: skuItem.detailUrl,
     imageUrl: skuItem.imageUrl,
+    referenceId: skuItem.referenceId,
   }
 }
 

--- a/react/__tests__/Wrapper.test.tsx
+++ b/react/__tests__/Wrapper.test.tsx
@@ -152,6 +152,9 @@ describe('Wrapper component', () => {
           parentPrice: 35,
           removed: [],
         },
+        referenceId: [
+          { Key: 'RefId', Value: '987134', __typename: 'Reference' },
+        ],
       },
     ]
 

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -199,6 +199,9 @@ describe('catalogToCart module', () => {
           parentPrice: 35,
           removed: [],
         },
+        referenceId: [
+          { Key: 'RefId', Value: '987134', __typename: 'Reference' },
+        ],
       },
     ]
 

--- a/react/modules/catalogItemToCart.ts
+++ b/react/modules/catalogItemToCart.ts
@@ -1,5 +1,3 @@
-import { path } from 'ramda'
-
 import {
   transformAssemblyOptions,
   sumAssembliesPrice,
@@ -30,6 +28,7 @@ export interface CartItem {
   sellingPriceWithAssemblies: number
   options: Option[]
   assemblyOptions: ParsedAssemblyOptionsMeta
+  referenceId: ProductContextItem['referenceId']
 }
 
 interface MapCatalogItemToCartArgs {
@@ -83,7 +82,7 @@ export function mapCatalogItemToCart({
       sellingPrice: selectedSeller.commertialOffer.Price * 100,
       sellingPriceWithAssemblies:
         ((selectedSeller.commertialOffer.Price as number) +
-          sumAssembliesPrice(path(['items'], assemblyOptions) ?? {})) *
+          sumAssembliesPrice(assemblyOptions?.items ?? {})) *
         100,
       measurementUnit: selectedItem.measurementUnit,
       skuSpecifications: [],
@@ -94,6 +93,7 @@ export function mapCatalogItemToCart({
         parentPrice: selectedSeller.commertialOffer.Price,
         parentQuantity: selectedQuantity,
       }),
+      referenceId: selectedItem.referenceId,
     },
   ]
 }


### PR DESCRIPTION
#### What does this PR do? \*

It adds the `referenceId` to the `addToCart` payload.

#### How to test it? \*

1) Go to https://kiwi--storecomponents.myvtex.com/tank-top/p
2) Click `add to cart`
2) Open dev tools, type `pixelManagerEvents` and check if the last entry is an `addToCart` event with a `referenceId` in its payload.

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

Partially fixes https://github.com/vtex-apps/pixel-app-template/issues/7. 
