### PR TITLE
Enable Selected Seller as a prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+-  New prop `selectedSeller`.
 
 ## [0.8.1] - 2020-03-24
 ### Fixed

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -13,6 +13,7 @@ interface Props {
   customToastUrl: string
   customOneClickBuyLink: string
   showToast: Function
+  selectedSeller: Seller | undefined
 }
 
 function checkAvailability(
@@ -61,6 +62,7 @@ const Wrapper: FC<Props> = ({
   customToastUrl,
   showToast,
   customOneClickBuyLink,
+  selectedSeller
 }) => {
   const productContext: ProductContextState = useProduct()
   const isEmptyContext = Object.keys(productContext).length === 0
@@ -68,7 +70,7 @@ const Wrapper: FC<Props> = ({
   const product = productContext?.product
   const selectedItem = productContext?.selectedItem
   const assemblyOptions = productContext?.assemblyOptions
-  const selectedSeller = productContext?.selectedItem?.sellers[0]
+  selectedSeller = selectedSeller ? selectedSeller : productContext?.selectedItem?.sellers[0]
   const selectedQuantity =
     productContext?.selectedQuantity != null
       ? productContext.selectedQuantity

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 function checkAvailability(
   isEmptyContext: boolean,
-  selectedSeller: Seller | undefined,
+  seller: Seller | undefined,
   availableProp: Props['available']
 ) {
   if (isEmptyContext) {
@@ -29,7 +29,7 @@ function checkAvailability(
   }
 
   const availableProductQuantity =
-    selectedSeller?.commertialOffer?.AvailableQuantity
+    seller?.commertialOffer?.AvailableQuantity
 
   return Boolean(availableProductQuantity)
 }
@@ -70,7 +70,7 @@ const Wrapper: FC<Props> = ({
   const product = productContext?.product
   const selectedItem = productContext?.selectedItem
   const assemblyOptions = productContext?.assemblyOptions
-  selectedSeller = selectedSeller ? selectedSeller : productContext?.selectedItem?.sellers[0]
+  const seller = selectedSeller ? selectedSeller : productContext?.selectedItem?.sellers[0]
   const selectedQuantity =
     productContext?.selectedQuantity != null
       ? productContext.selectedQuantity
@@ -82,15 +82,15 @@ const Wrapper: FC<Props> = ({
         product,
         selectedItem,
         selectedQuantity,
-        selectedSeller,
+        selectedSeller: seller,
         assemblyOptions,
       }),
-    [assemblyOptions, product, selectedItem, selectedQuantity, selectedSeller]
+    [assemblyOptions, product, selectedItem, selectedQuantity, seller]
   )
 
   const isAvailable = checkAvailability(
     isEmptyContext,
-    selectedSeller,
+    seller,
     available
   )
 


### PR DESCRIPTION
#### What does this PR do? \*

Enable te Selected Seller of a item to be defined via prop, making possible to add skus with specific  sellers to the cart

#### How to test it? \*

https://addtocart--cosmetics2.myvtex.com/sellers/creme---100--vegano-12

Same item, different sellers
Each button will add the specific seller to the cart

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

Related To:
Seller-Sellector
Enable seller-selector on go-commerce
