### PR TITLE
Add goToProductPage prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.12.0] - 2020-06-03
+### Added
+- `goToProductPage` prop to redirect user to product page (when `true`).
+
 ## [0.11.1] - 2020-06-03
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 
 | Prop name               | Type      | Description                                                                       | Default value        |
 | ----------------------- | --------- | --------------------------------------------------------------------------------- | -------------------- |
+| `goToProductPage`       | `boolean` | Whether the user should be redirected to the product page but the product will not be added to cart (`true`) or not (`false`) | `false`              |
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastURL`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -28,6 +28,8 @@ interface Props {
   allSkuVariationsSelected: boolean
   text?: string
   unavailableText?: string
+  linkText: string | undefined
+  goToProductPage: boolean | null
 }
 
 const CSS_HANDLES = [
@@ -88,6 +90,8 @@ function AddToCartButton(props: Props) {
     unavailableText,
     customOneClickBuyLink,
     allSkuVariationsSelected = true,
+    linkText,
+    goToProductPage = false,
   } = props
 
   const intl = useIntl()
@@ -121,9 +125,9 @@ function AddToCartButton(props: Props) {
 
     const action = success
       ? {
-          label: translateMessage(messages.seeCart),
-          href: customToastUrl,
-        }
+        label: translateMessage(messages.seeCart),
+        href: customToastUrl,
+      }
       : undefined
 
     showToast({ message, action })
@@ -132,6 +136,10 @@ function AddToCartButton(props: Props) {
   const handleAddToCart: React.MouseEventHandler = event => {
     event.stopPropagation()
     event.preventDefault()
+
+    if (goToProductPage && linkText) {
+      return navigate({ to: `/${linkText}/p` })
+    }
 
     const itemsAdded = addItem(skuItems, { ...utmParams, ...utmiParams })
     const pixelEventItems = skuItems.map(adjustSkuItemForPixelEvent)
@@ -180,20 +188,20 @@ function AddToCartButton(props: Props) {
       {text ? (
         <span className={handles.buttonText}>{text}</span>
       ) : (
-        <FormattedMessage id="store/add-to-cart.add-to-cart">
-          {message => <span className={handles.buttonText}>{message}</span>}
-        </FormattedMessage>
-      )}
+          <FormattedMessage id="store/add-to-cart.add-to-cart">
+            {message => <span className={handles.buttonText}>{message}</span>}
+          </FormattedMessage>
+        )}
     </div>
   )
 
   const unavailableButtonContent = unavailableText ? (
     <span className={handles.buttonText}>{unavailableText}</span>
   ) : (
-    <FormattedMessage id="store/add-to-cart.label-unavailable">
-      {message => <span className={handles.buttonText}>{message}</span>}
-    </FormattedMessage>
-  )
+      <FormattedMessage id="store/add-to-cart.label-unavailable">
+        {message => <span className={handles.buttonText}>{message}</span>}
+      </FormattedMessage>
+    )
 
   const tooltipLabel = (
     <span className={handles.tooltipLabelText}>
@@ -210,10 +218,10 @@ function AddToCartButton(props: Props) {
   return allSkuVariationsSelected ? (
     ButtonWithLabel
   ) : (
-    <Tooltip trigger="click" label={tooltipLabel}>
-      {ButtonWithLabel}
-    </Tooltip>
-  )
+      <Tooltip trigger="click" label={tooltipLabel}>
+        {ButtonWithLabel}
+      </Tooltip>
+    )
 }
 
 export default AddToCartButton

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -16,6 +16,7 @@ interface Props {
   selectedSeller: Seller | undefined
   text?: string
   unavailableText?: string
+  goToProductPage: boolean | null
 }
 
 function checkAvailability(
@@ -67,6 +68,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     selectedSeller,
     unavailableText,
     text,
+    goToProductPage,
   } = props
   const productContext: ProductContextState = useProduct()
   const isEmptyContext = Object.keys(productContext).length === 0
@@ -111,6 +113,8 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       unavailableText={unavailableText}
       customOneClickBuyLink={customOneClickBuyLink}
       allSkuVariationsSelected={areAllSkuVariationsSelected}
+      linkText={product?.linkText}
+      goToProductPage={goToProductPage}
     />
   )
 })


### PR DESCRIPTION
#### What does this PR do? \*
Allow redirect user to product page when add-to-cart-button is clicked and it have **goToProductPage** prop as `true`

#### How to test it? \*
https://buttonpdp--minisomx.myvtex.com/Salud-Y-Belleza/Farmacia/Cubrebocas

#### Describe alternatives you've considered, if any. \*
I tried to use product-summary:buy-button but, with minicart.v2 it's not working good.

<!--- Optional -->

#### Related to / Depends on \*
#27 
<!--- Optional -->
