### PR TITLE
Add support for redirecting users to product pages when there are multiple SKUs for the same product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.12.0] - 2020-06-10
+### Added
+- Support for redirecting users to product pages when there are multiple SKUs for the same product.
 
 ## [0.12.0] - 2020-06-04
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 
 | Prop name               | Type      | Description                                                                       | Default value        |
 | ----------------------- | --------- | --------------------------------------------------------------------------------- | -------------------- |
-| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `go-to-product-page-multiple-available-skus`. | `add-to-cart`              |
+| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `ensure-sku-selection`, which means that users will be redirected to the product's page if there are multiple available SKUs, and added to the cart otherwise. | `add-to-cart`              |
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastURL`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 
 | Prop name               | Type      | Description                                                                       | Default value        |
 | ----------------------- | --------- | --------------------------------------------------------------------------------- | -------------------- |
-| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `ensure-sku-selection`, which means that users will be redirected to the product's page if there are multiple available SKUs, and added to the cart otherwise. | `add-to-cart`              |
+| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `ensure-sku-selection`, which means that users will be redirected to the product's page if there are multiple available SKUs, and the product would be added to the cart otherwise. | `add-to-cart`              |
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastURL`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 
 | Prop name               | Type      | Description                                                                       | Default value        |
 | ----------------------- | --------- | --------------------------------------------------------------------------------- | -------------------- |
-| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `ensure-sku-selection`, which means that users will be redirected to the product's page if there are multiple available SKUs, and the product would be added to the cart otherwise. | `add-to-cart`              |
+| `onClickBehavior`       | `enum` | Controls what happens when users click on the button. Possible values are: `go-to-product-page`, `add-to-cart`, and `ensure-sku-selection` (if multiple SKUs are available, users will be redirected to the product page to select the desired one. If the product only has 1 SKU available, it will be added to the cart once the button is clicked on). | `add-to-cart`              |
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastURL`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 
 | Prop name               | Type      | Description                                                                       | Default value        |
 | ----------------------- | --------- | --------------------------------------------------------------------------------- | -------------------- |
-| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page` or `add-to-cart`. | `add-to-cart`              |
+| `onClickBehavior`       | `enum` | Controls what happens when users click the button. Possible values are: `go-to-product-page`, `add-to-cart` and `go-to-product-page-multiple-available-skus`. | `add-to-cart`              |
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastURL`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -130,17 +130,20 @@ function AddToCartButton(props: Props) {
 
     const action = success
       ? {
-        label: translateMessage(messages.seeCart),
-        href: customToastUrl,
-      }
+          label: translateMessage(messages.seeCart),
+          href: customToastUrl,
+        }
       : undefined
 
     showToast({ message, action })
   }
 
   const handleAddToCart: React.MouseEventHandler = event => {
-
-    if (onClickBehavior === "go-to-product-page" && productLink.linkText && productLink.productId) {
+    if (
+      onClickBehavior === 'go-to-product-page' &&
+      productLink.linkText &&
+      productLink.productId
+    ) {
       event.stopPropagation()
       event.preventDefault()
       return navigate({
@@ -148,7 +151,7 @@ function AddToCartButton(props: Props) {
         params: {
           slug: productLink.linkText,
           id: productLink.productId,
-        }
+        },
       })
     }
 
@@ -202,20 +205,20 @@ function AddToCartButton(props: Props) {
       {text ? (
         <span className={handles.buttonText}>{text}</span>
       ) : (
-          <FormattedMessage id="store/add-to-cart.add-to-cart">
-            {message => <span className={handles.buttonText}>{message}</span>}
-          </FormattedMessage>
-        )}
+        <FormattedMessage id="store/add-to-cart.add-to-cart">
+          {message => <span className={handles.buttonText}>{message}</span>}
+        </FormattedMessage>
+      )}
     </div>
   )
 
   const unavailableButtonContent = unavailableText ? (
     <span className={handles.buttonText}>{unavailableText}</span>
   ) : (
-      <FormattedMessage id="store/add-to-cart.label-unavailable">
-        {message => <span className={handles.buttonText}>{message}</span>}
-      </FormattedMessage>
-    )
+    <FormattedMessage id="store/add-to-cart.label-unavailable">
+      {message => <span className={handles.buttonText}>{message}</span>}
+    </FormattedMessage>
+  )
 
   const tooltipLabel = (
     <span className={handles.tooltipLabelText}>
@@ -232,10 +235,10 @@ function AddToCartButton(props: Props) {
   return allSkuVariationsSelected ? (
     ButtonWithLabel
   ) : (
-      <Tooltip trigger="click" label={tooltipLabel}>
-        {ButtonWithLabel}
-      </Tooltip>
-    )
+    <Tooltip trigger="click" label={tooltipLabel}>
+      {ButtonWithLabel}
+    </Tooltip>
+  )
 }
 
 export default AddToCartButton

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -35,10 +35,7 @@ interface Props {
   text?: string
   unavailableText?: string
   productLink: ProductLink
-  onClickBehavior:
-    | 'add-to-cart'
-    | 'go-to-product-page'
-    | 'go-to-product-page-multiple-available-skus'
+  onClickBehavior: 'add-to-cart' | 'go-to-product-page' | 'ensure-sku-selection'
 }
 
 const CSS_HANDLES = [
@@ -152,8 +149,7 @@ function AddToCartButton(props: Props) {
     )
     const shouldNavigateToProductPage =
       onClickBehavior === 'go-to-product-page' ||
-      (onClickBehavior === 'go-to-product-page-multiple-available-skus' &&
-        multipleAvailableSKUs)
+      (onClickBehavior === 'ensure-sku-selection' && multipleAvailableSKUs)
 
     if (productLinkIsValid && shouldNavigateToProductPage) {
       return navigate({

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -19,7 +19,7 @@ interface Props {
   onClickBehavior?:
     | 'add-to-cart'
     | 'go-to-product-page'
-    | 'go-to-product-page-multiple-available-skus'
+    | 'ensure-sku-selection'
 }
 
 function checkAvailability(

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -16,7 +16,10 @@ interface Props {
   selectedSeller: Seller | undefined
   text?: string
   unavailableText?: string
-  onClickBehavior?: 'add-to-cart' | 'go-to-product-page'
+  onClickBehavior?:
+    | 'add-to-cart'
+    | 'go-to-product-page'
+    | 'go-to-product-page-multiple-available-skus'
 }
 
 function checkAvailability(
@@ -74,6 +77,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
   const isEmptyContext = Object.keys(productContext).length === 0
 
   const product = productContext?.product
+  const multipleAvailableSKUs = product ? product.items.length > 1 : false
   const selectedItem = productContext?.selectedItem
   const assemblyOptions = productContext?.assemblyOptions
   const seller = selectedSeller ?? productContext?.selectedItem?.sellers[0]
@@ -120,6 +124,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       allSkuVariationsSelected={areAllSkuVariationsSelected}
       productLink={productLink}
       onClickBehavior={onClickBehavior}
+      multipleAvailableSKUs={multipleAvailableSKUs}
     />
   )
 })

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -101,7 +101,10 @@ const Wrapper = withToast(function Wrapper(props: Props) {
   const areAllSkuVariationsSelected =
     !isEmptyContext && productContext?.skuSelector.areAllVariationsSelected
 
-  const productLink = { linkText: product?.linkText, productId: product?.productId }
+  const productLink = {
+    linkText: product?.linkText,
+    productId: product?.productId,
+  }
 
   return (
     <AddToCartButton

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -45,8 +45,14 @@ const mockMarketingData = {
   utmiPart: 'testing utmiPart',
 }
 
+const mockProductLink = {
+  linkText: 'mock-product',
+  productId: '2000024',
+}
+
 const mockAddItem = jest.fn()
 const mockPixelEventPush = jest.fn()
+const mockNavigate = jest.fn()
 
 jest.mock('../hooks/useMarketingSessionParams', () => {
   return () => ({
@@ -73,9 +79,17 @@ jest.mock('vtex.pixel-manager/PixelContext', () => ({
   usePixel: () => ({ push: mockPixelEventPush }),
 }))
 
+jest.mock('vtex.render-runtime', () => ({
+  useRuntime: () => ({
+    rootPath: '',
+    navigate: mockNavigate,
+  }),
+}))
+
 afterEach(() => {
   mockAddItem.mockClear()
   mockPixelEventPush.mockClear()
+  mockNavigate.mockClear()
   cleanup()
 })
 
@@ -91,6 +105,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -108,6 +125,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -125,6 +145,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected={false}
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -146,6 +169,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -163,6 +189,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -190,6 +219,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -217,6 +249,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -265,6 +300,9 @@ describe('AddToCartButton component', () => {
         customToastUrl=""
         showToast={() => {}}
         allSkuVariationsSelected={false}
+        productLink={mockProductLink}
+        onClickBehavior="add-to-cart"
+        multipleAvailableSKUs={false}
       />
     )
 
@@ -279,5 +317,79 @@ describe('AddToCartButton component', () => {
     })
 
     expect(mockAddItem).toHaveBeenCalledTimes(0)
+  })
+
+  it("should navigate to product page if onClickBehavior is set to 'go-to-product-page'", () => {
+    const { queryByTestId } = render(
+      <AddToCartButton
+        isOneClickBuy={false}
+        available
+        customOneClickBuyLink=""
+        disabled={false}
+        skuItems={mockSKUItems}
+        customToastUrl=""
+        showToast={() => {}}
+        allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="go-to-product-page"
+        multipleAvailableSKUs={false}
+      />
+    )
+
+    const button = queryByTestId('styleguide-button')
+
+    expect(button).toBeTruthy()
+
+    act(() => {
+      if (button) {
+        fireEvent.click(button)
+      }
+    })
+
+    expect(mockAddItem).toHaveBeenCalledTimes(0)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      page: 'store.product',
+      params: {
+        slug: 'mock-product',
+        id: '2000024',
+      },
+    })
+  })
+
+  it("should navigate to product page if onClickBehavior is set to 'go-to-product-page-multiple-available-skus' and product has multiple SKUs", () => {
+    const { queryByTestId } = render(
+      <AddToCartButton
+        isOneClickBuy={false}
+        available
+        customOneClickBuyLink=""
+        disabled={false}
+        skuItems={mockSKUItems}
+        customToastUrl=""
+        showToast={() => {}}
+        allSkuVariationsSelected
+        productLink={mockProductLink}
+        onClickBehavior="go-to-product-page-multiple-available-skus"
+        multipleAvailableSKUs
+      />
+    )
+
+    const button = queryByTestId('styleguide-button')
+
+    expect(button).toBeTruthy()
+
+    act(() => {
+      if (button) {
+        fireEvent.click(button)
+      }
+    })
+
+    expect(mockAddItem).toHaveBeenCalledTimes(0)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      page: 'store.product',
+      params: {
+        slug: 'mock-product',
+        id: '2000024',
+      },
+    })
   })
 })

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -356,7 +356,7 @@ describe('AddToCartButton component', () => {
     })
   })
 
-  it("should navigate to product page if onClickBehavior is set to 'go-to-product-page-multiple-available-skus' and product has multiple SKUs", () => {
+  it("should navigate to product page if onClickBehavior is set to 'ensure-sku-selection' and product has multiple SKUs", () => {
     const { queryByTestId } = render(
       <AddToCartButton
         isOneClickBuy={false}
@@ -368,7 +368,7 @@ describe('AddToCartButton component', () => {
         showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
-        onClickBehavior="go-to-product-page-multiple-available-skus"
+        onClickBehavior="ensure-sku-selection"
         multipleAvailableSKUs
       />
     )


### PR DESCRIPTION
#### What problem is this solving?

The `add-to-cart-button` block currently supports the following two behaviors after a user clicks on it:

- Always adding the product in the closest context to the `minicart`;
- Always redirecting the user to the product's page, and not adding the item in the `minicart`.

With this PR we're adding support for one more behavior

- Redirect users to the product's page **only** when the product has multiple SKUs available,  adding the item to the `minicart` otherwise.

Users will be able to activate this new behavior through the `onClickBehavior` prop, setting it to `ensure-sku-selection`.

#### How to test it?

1. Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/apparel---accessories/?page=2);
2. Click the "ADD TO CART" button for the product "Top Everyday Necessaire". This product only has **one** SKU available, so it should go straight into the `minicart`;
3. Now try the same thing with "Classic Shoes Top". This product has multiple available SKUs, it should **not** be added to the `minicart` right away. Instead, you should've been redirected to it's PDP.

To achieve this behavior, the only addition to our default `store-theme` is the following

```diff
  "add-to-cart-button": {
    "props": {
+      "onClickBehavior": "ensure-sku-selection"
     }
   }
```

#### Screenshots or example usage:


![Jul-02-2020 14-14-02](https://user-images.githubusercontent.com/27777263/86390369-506d8280-bc6e-11ea-9cda-b5b94d08d052.gif)

Sorry about the quality 😅 .

#### How does this PR make you feel? [:link:](http://giphy.com/)

This came from a request made at https://ideas.vtex.com/ sooo

![](https://media.giphy.com/media/l3nWqzkMR5diFKkkU/giphy.gif)
