### PR TITLE
Fix/loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix minicart breaking if product category tree query resolvers before the whole product query.
-- Use proper for product in ProductContextState.
+- Minicart breaking if product category tree query resolves before the whole product query.
+- Use proper type for `product` in `ProductContextState`.
 
 ## [0.13.1] - 2020-07-09
 ### Fixed
@@ -95,4 +95,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.0] - 2019-11-18
 ### Added
 - Initial release.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fix minicart breaking if product category tree query resolvers before the whole product query.
+- Use proper for product in ProductContextState.
 
 ## [0.13.1] - 2020-07-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix minicart breaking if product category tree query resolvers before the whole product query.
 
 ## [0.13.1] - 2020-07-09
 ### Fixed

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -77,7 +77,8 @@ const Wrapper = withToast(function Wrapper(props: Props) {
   const isEmptyContext = Object.keys(productContext).length === 0
 
   const product = productContext?.product
-  const multipleAvailableSKUs = product ? product.items?.length > 1 : false
+  const itemsLength = product?.items?.length ?? 0
+  const multipleAvailableSKUs = itemsLength > 1
   const selectedItem = productContext?.selectedItem
   const assemblyOptions = productContext?.assemblyOptions
   const seller = selectedSeller ?? productContext?.selectedItem?.sellers[0]

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -17,9 +17,9 @@ interface Props {
   text?: string
   unavailableText?: string
   onClickBehavior?:
-    | 'add-to-cart'
-    | 'go-to-product-page'
-    | 'ensure-sku-selection'
+  | 'add-to-cart'
+  | 'go-to-product-page'
+  | 'ensure-sku-selection'
 }
 
 function checkAvailability(
@@ -77,7 +77,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
   const isEmptyContext = Object.keys(productContext).length === 0
 
   const product = productContext?.product
-  const multipleAvailableSKUs = product ? product.items.length > 1 : false
+  const multipleAvailableSKUs = product ? product.items?.length > 1 : false
   const selectedItem = productContext?.selectedItem
   const assemblyOptions = productContext?.assemblyOptions
   const seller = selectedSeller ?? productContext?.selectedItem?.sellers[0]

--- a/react/modules/catalogItemToCart.ts
+++ b/react/modules/catalogItemToCart.ts
@@ -32,7 +32,7 @@ export interface CartItem {
 }
 
 interface MapCatalogItemToCartArgs {
-  product: Maybe<Product>
+  product: ProductContextState['product']
   selectedItem: Maybe<ProductContextItem>
   selectedQuantity: number
   selectedSeller: any
@@ -63,17 +63,17 @@ export function mapCatalogItemToCart({
     {
       index: 0,
       id: selectedItem.itemId,
-      productId: product.productId,
+      productId: product.productId ?? '',
       quantity: selectedQuantity,
       uniqueId: '',
       detailUrl: `/${product.linkText}/p`,
-      name: product.productName,
-      brand: product.brand,
+      name: product.productName ?? '',
+      brand: product.brand ?? '',
       category:
         product.categories && product.categories.length > 0
           ? product.categories[0]
           : '',
-      productRefId: product.productReference,
+      productRefId: product.productReference ?? '',
       seller: selectedSeller.sellerId,
       variant: selectedItem.name,
       skuName: selectedItem.name,

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -39,7 +39,7 @@ interface BuyButtonContextState {
 
 interface ProductContextState {
   selectedItem: Maybe<ProductContextItem>
-  product: Maybe<Product>
+  product: Maybe<Partial<Product>>
   selectedQuantity: number
   skuSelector: {
     isVisible: boolean


### PR DESCRIPTION
#### What problem is this solving?

When for some reason the product query made in server cannot be used and we have to make the product query in the client, the category tree query we do in parallel resolves first and in that moment we have a product in context with only the categoryTree field not undefined. So when we tried to access `product.items.length` it would break because items is undefined at that moment.

We need our code to deal with this possibility.

Also, make use of `Partial<T>` to make all possible keys of the product to be undefined, since it is true because we never know in what orders the queries resolve if done in client.

#### How to test it?

- Navigate to the Garrafa's product page. Watch the loading state be displayed and the component not break

https://loading--ioqa.myvtex.com/

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
