### PR TITLE
Add skuItems prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `skuItems` prop to add more than one item to the cart.
 
 ## [0.13.4] - 2020-07-23
 ### Fixed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -80,7 +80,7 @@ const adjustSkuItemForPixelEvent = (skuItem: CartItem) => {
     category,
     detailUrl: skuItem.detailUrl,
     imageUrl: skuItem.imageUrl,
-    referenceId: skuItem?.referenceId?.[0].Value,
+    referenceId: skuItem?.referenceId?.[0]?.Value,
   }
 }
 

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -3,7 +3,7 @@ import useProduct from 'vtex.product-context/useProduct'
 import { withToast } from 'vtex.styleguide'
 
 import AddToCartButton from './AddToCartButton'
-import { mapCatalogItemToCart } from './modules/catalogItemToCart'
+import { mapCatalogItemToCart, CartItem } from './modules/catalogItemToCart'
 import { AssemblyOptions } from './modules/assemblyOptions'
 
 interface Props {
@@ -20,6 +20,7 @@ interface Props {
     | 'add-to-cart'
     | 'go-to-product-page'
     | 'ensure-sku-selection'
+  skuItems?: CartItem[]
 }
 
 function checkAvailability(
@@ -89,6 +90,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
 
   const skuItems = useMemo(
     () =>
+      props.skuItems ??
       mapCatalogItemToCart({
         product,
         selectedItem,
@@ -96,7 +98,14 @@ const Wrapper = withToast(function Wrapper(props: Props) {
         selectedSeller: seller,
         assemblyOptions,
       }),
-    [assemblyOptions, product, selectedItem, selectedQuantity, seller]
+    [
+      assemblyOptions,
+      product,
+      props.skuItems,
+      selectedItem,
+      selectedQuantity,
+      seller,
+    ]
   )
 
   const isAvailable = checkAvailability(isEmptyContext, seller, available)

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -34,6 +34,31 @@ const mockSKUItems = [
     },
     referenceId: [{ Key: 'Reference', Value: 'red star' }],
   },
+  {
+    id: '2000535',
+    productId: '2000004',
+    quantity: 1,
+    uniqueId: '',
+    detailUrl: '/st-tropez-shorts/p',
+    name: 'St Tropez Top Shorts',
+    brand: 'Samsung',
+    category: '/Apparel & Accessories/Clothing/Bottoms/',
+    productRefId: '01212',
+    seller: '1',
+    variant: 'Navy Blue',
+    skuName: 'Navy Blue',
+    price: 303000,
+    listPrice: 303000,
+    sellingPrice: 303000,
+    sellingPriceWithAssemblies: 303000,
+    measurementUnit: 'un',
+    skuSpecifications: [],
+    imageUrl:
+      'https://storecomponents.vtexassets.com/arquivos/ids/155488-500-auto?width=500&height=auto&aspect=true',
+    options: [],
+    assemblyOptions: { added: [], removed: [], parentPrice: 3030 },
+    referenceId: null,
+  },
 ]
 
 const mockMarketingData = {
@@ -282,6 +307,21 @@ describe('AddToCartButton component', () => {
           imageUrl:
             'https://storecomponents.vtexassets.com/arquivos/ids/155518/download--40-.png?v=636942495289870000',
           referenceId: 'red star',
+        },
+        {
+          skuId: '2000535',
+          variant: 'Navy Blue',
+          price: 303000,
+          name: 'St Tropez Top Shorts',
+          quantity: 1,
+          productId: '2000004',
+          productRefId: '01212',
+          brand: 'Samsung',
+          category: 'Apparel & Accessories/Clothing/Bottoms',
+          detailUrl: '/st-tropez-shorts/p',
+          imageUrl:
+            'https://storecomponents.vtexassets.com/arquivos/ids/155488-500-auto?width=500&height=auto&aspect=true',
+          referenceId: undefined,
         },
       ],
     }

--- a/react/__tests__/Wrapper.test.tsx
+++ b/react/__tests__/Wrapper.test.tsx
@@ -165,4 +165,73 @@ describe('Wrapper component', () => {
       {}
     )
   })
+
+  it('should pass correct skuItems received from props to AddToCartButton', () => {
+    const mockSKUItems = [
+      {
+        index: 0,
+        id: '2000564',
+        productId: '2000024',
+        quantity: 1,
+        uniqueId: '',
+        detailUrl: '/star-color-top/p',
+        name: 'Top Star Color Shirt',
+        brand: 'Kawasaki',
+        category: '/Apparel & Accessories/Clothing/Tops/',
+        productRefId: '998765',
+        seller: '1',
+        variant: 'Red star',
+        skuName: 'Red star',
+        price: 3500,
+        listPrice: 3500,
+        sellingPrice: 3500,
+        sellingPriceWithAssemblies: 3500,
+        measurementUnit: 'un',
+        skuSpecifications: [],
+        imageUrl:
+          'https://storecomponents.vtexassets.com/arquivos/ids/155518/download--40-.png?v=636942495289870000',
+        options: [],
+        assemblyOptions: {
+          added: [],
+          parentPrice: 35,
+          removed: [],
+        },
+        referenceId: [{ Key: 'Reference', Value: 'red star' }],
+      },
+      {
+        id: '2000535',
+        productId: '2000004',
+        quantity: 1,
+        uniqueId: '',
+        detailUrl: '/st-tropez-shorts/p',
+        name: 'St Tropez Top Shorts',
+        brand: 'Samsung',
+        category: '/Apparel & Accessories/Clothing/Bottoms/',
+        productRefId: '01212',
+        seller: '1',
+        variant: 'Navy Blue',
+        skuName: 'Navy Blue',
+        price: 303000,
+        listPrice: 303000,
+        sellingPrice: 303000,
+        sellingPriceWithAssemblies: 303000,
+        measurementUnit: 'un',
+        skuSpecifications: [],
+        imageUrl:
+          'https://storecomponents.vtexassets.com/arquivos/ids/155488-500-auto?width=500&height=auto&aspect=true',
+        options: [],
+        assemblyOptions: { added: [], removed: [], parentPrice: 3030 },
+        referenceId: { Value: '' },
+      },
+    ]
+
+    renderWithProductContext(<Wrapper skuItems={mockSKUItems} />, {})
+
+    expect(MockAddToCartButton).toBeCalledWith(
+      expect.objectContaining({
+        skuItems: mockSKUItems,
+      }),
+      {}
+    )
+  })
 })


### PR DESCRIPTION
#### What problem is this solving?
With this prop, you can add multiple items to the cart by clicking on a single button.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta3--storecomponents.myvtex.com/blouse-with-knot/p)
- Click the `Add to cart` button on the `BuyTogether` shelf

#### Screenshots or example usage:

![addtocart](https://user-images.githubusercontent.com/20840671/87463820-712bc580-c5e8-11ea-80f8-e773f3a61f7e.gif)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/lpHPFVpk65qpbH2XY5/giphy.gif)
