### PR TITLE
Add callback after items are added to cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Callback after items are added to cart.
 
 ## [0.13.3] - 2020-07-16
 ### Fixed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -36,6 +36,7 @@ interface Props {
   unavailableText?: string
   productLink: ProductLink
   onClickBehavior: 'add-to-cart' | 'go-to-product-page' | 'ensure-sku-selection'
+  onAddedToCart?: () => void | Promise<void>
 }
 
 const CSS_HANDLES = [
@@ -99,6 +100,7 @@ function AddToCartButton(props: Props) {
     productLink,
     onClickBehavior,
     multipleAvailableSKUs,
+    onAddedToCart,
   } = props
 
   const intl = useIntl()
@@ -140,7 +142,7 @@ function AddToCartButton(props: Props) {
     showToast({ message, action })
   }
 
-  const handleAddToCart: React.MouseEventHandler = event => {
+  const handleAddToCart: React.MouseEventHandler = async event => {
     event.stopPropagation()
     event.preventDefault()
 
@@ -168,6 +170,8 @@ function AddToCartButton(props: Props) {
       event: 'addToCart',
       items: pixelEventItems,
     })
+
+    await onAddedToCart?.()
 
     if (isOneClickBuy) {
       if (

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -17,9 +17,10 @@ interface Props {
   text?: string
   unavailableText?: string
   onClickBehavior?:
-  | 'add-to-cart'
-  | 'go-to-product-page'
-  | 'ensure-sku-selection'
+    | 'add-to-cart'
+    | 'go-to-product-page'
+    | 'ensure-sku-selection'
+  onAddedToCart?: () => void | Promise<void>
 }
 
 function checkAvailability(
@@ -72,6 +73,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     unavailableText,
     text,
     onClickBehavior = 'add-to-cart',
+    onAddedToCart,
   } = props
   const productContext: ProductContextState = useProduct()
   const isEmptyContext = Object.keys(productContext).length === 0
@@ -126,6 +128,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       productLink={productLink}
       onClickBehavior={onClickBehavior}
       multipleAvailableSKUs={multipleAvailableSKUs}
+      onAddedToCart={onAddedToCart}
     />
   )
 })


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a callback so we can customize the behaviour of the button after the items are added to cart. We can leverage this to, for example, set the payment system in the order form so the price can be consistent from the PDP to the payment step in Checkout (for scenarios where we have a promotion in a specific payment method).

#### How to test it?

1. Add this [product](https://promo--vtexgame1.myvtex.com/novalgina/p) to your cart.
2. Verify that, after added, it will have a lower price than the one showed in the PDP (because of the payment method promotion).

#### Describe alternatives you've considered, if any.

There is a on going discussion around this issue, and these changes will allow for a quick win in regard for this problem (although it won't, and shouldn't, be fully resolved with this).

#### Related to / Depends on

N/A