### PR TITLE
Add recursive input values in the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-
 - Handling of recursive input values in assembly options.
 
 ## [0.13.3] - 2020-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Handling of recursive input values in assembly options.
 
 ## [0.13.3] - 2020-07-16
 ### Fixed

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -17,9 +17,9 @@ interface Props {
   text?: string
   unavailableText?: string
   onClickBehavior?:
-  | 'add-to-cart'
-  | 'go-to-product-page'
-  | 'ensure-sku-selection'
+    | 'add-to-cart'
+    | 'go-to-product-page'
+    | 'ensure-sku-selection'
 }
 
 function checkAvailability(

--- a/react/__fixtures__/assemblyOptions.ts
+++ b/react/__fixtures__/assemblyOptions.ts
@@ -1,6 +1,6 @@
 import { AssemblyOptions } from '../modules/assemblyOptions'
 
-export const customBell = {
+export const customBell: AssemblyOptions = {
   items: {
     'add-on_Add-on': [
       {
@@ -83,7 +83,13 @@ export const customBell = {
       },
     ],
   },
-  inputValues: {},
+  inputValues: {
+    '1-3-lines': {
+      'Line 1': 'First line',
+      'Line 2': 'Second line',
+      'Line 3': 'Third line',
+    },
+  },
   areGroupsValid: {
     'add-on_Add-on': true,
     'text_style_Text Style': true,

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -79,19 +79,18 @@ describe('assemblyOptions module', () => {
   })
 
   describe('transformAssemblyOptions function', () => {
-    it('should correctly transform full assembly options', () => {
+    it('should transform assemblyOptions', () => {
       const parentPrice = 450
       const parentQuantity = 1
 
       const resultBell = transformAssemblyOptions({
-        assemblyOptionsItems: customBell.items as any,
+        assemblyOptionsItems: customBell.items,
         inputValues: {},
         parentPrice,
         parentQuantity,
       })
 
       expect(resultBell.options).toHaveLength(5)
-
       const addonOption = resultBell.options[0] as ItemOption
       expect(addonOption.assemblyId).toBe('add-on_Add-on')
       expect(addonOption.id).toBe('2000588')
@@ -106,7 +105,6 @@ describe('assemblyOptions module', () => {
       })
 
       expect(resultPizza.options).toHaveLength(2)
-
       const pizzaOption = resultPizza.options[0] as ItemOption
       expect(pizzaOption.assemblyId).toBe('pizza_composition_Pizza flavor')
       expect(pizzaOption.id).toBe('5101')
@@ -118,7 +116,7 @@ describe('assemblyOptions module', () => {
       expect(drinksOptions.options).toBeUndefined()
     })
 
-    it('should correctly transform assembly options with input values', () => {
+    it('input values', () => {
       const parentPrice = 450
       const parentQuantity = 1
 
@@ -130,8 +128,7 @@ describe('assemblyOptions module', () => {
       })
 
       expect(resultStar.options).toHaveLength(1)
-
-      const [customization] = resultStar.options
+      const customization = resultStar.options[0] as ItemOption
       expect(customization.assemblyId).toBe('Customization')
       expect(customization.inputValues).toMatchObject({
         Font: 'Sans serif',
@@ -139,6 +136,154 @@ describe('assemblyOptions module', () => {
         'Back text': 'Verso',
         'Glossy print': true,
       })
+      expect(resultStar).toMatchInlineSnapshot(`
+        Object {
+          "assemblyOptions": Object {
+            "added": Array [],
+            "parentPrice": 450,
+            "removed": Array [],
+          },
+          "options": Array [
+            Object {
+              "assemblyId": "Customization",
+              "inputValues": Object {
+                "Back text": "Verso",
+                "Font": "Sans serif",
+                "Front text": "Frente",
+                "Glossy print": true,
+              },
+            },
+          ],
+        }
+      `)
+    })
+
+    it('recursive input values', () => {
+      const parentPrice = 450
+      const parentQuantity = 1
+
+      const resultBell = transformAssemblyOptions({
+        assemblyOptionsItems: customBell.items,
+        inputValues: customBell.inputValues,
+        parentPrice,
+        parentQuantity,
+      })
+
+      expect(resultBell.options).toHaveLength(5)
+
+      const engraving = resultBell.options[4] as ItemOption
+      expect(engraving.options).toHaveLength(1)
+
+      const recursiveInputValue = engraving.options![0] as ItemOption
+      expect(recursiveInputValue.assemblyId).toBe('1-3-lines')
+      expect(recursiveInputValue.inputValues).toBe(
+        customBell.inputValues['1-3-lines']
+      )
+      expect(resultBell).toMatchInlineSnapshot(`
+        Object {
+          "assemblyOptions": Object {
+            "added": Array [
+              Object {
+                "choiceType": "TOGGLE",
+                "extraQuantity": 1,
+                "item": Object {
+                  "id": "2000588",
+                  "name": "Bells add-ons Logo small",
+                  "quantity": 1,
+                  "sellingPrice": 75,
+                  "sellingPriceWithAssemblies": 75,
+                },
+                "normalizedQuantity": 1,
+              },
+              Object {
+                "choiceType": "TOGGLE",
+                "extraQuantity": 1,
+                "item": Object {
+                  "id": "2000589",
+                  "name": "Bells add-ons Logo big",
+                  "quantity": 1,
+                  "sellingPrice": 90,
+                  "sellingPriceWithAssemblies": 90,
+                },
+                "normalizedQuantity": 1,
+              },
+              Object {
+                "choiceType": "SINGLE",
+                "extraQuantity": 1,
+                "item": Object {
+                  "id": "2000592",
+                  "name": "Bells add-ons Script",
+                  "quantity": 1,
+                  "sellingPrice": 15,
+                  "sellingPriceWithAssemblies": 15,
+                },
+                "normalizedQuantity": 1,
+              },
+              Object {
+                "choiceType": "SINGLE",
+                "extraQuantity": 1,
+                "item": Object {
+                  "assemblyOptions": Object {
+                    "added": Array [],
+                    "parentPrice": 26,
+                    "removed": Array [],
+                  },
+                  "id": "2000586",
+                  "name": "Bells add-ons 1-3 lines",
+                  "quantity": 1,
+                  "sellingPrice": 26,
+                  "sellingPriceWithAssemblies": 26,
+                },
+                "normalizedQuantity": 1,
+              },
+            ],
+            "parentPrice": 450,
+            "removed": Array [],
+          },
+          "options": Array [
+            Object {
+              "assemblyId": "add-on_Add-on",
+              "id": "2000588",
+              "quantity": 1,
+              "seller": "1",
+            },
+            Object {
+              "assemblyId": "add-on_Add-on",
+              "id": "2000589",
+              "quantity": 1,
+              "seller": "1",
+            },
+            Object {
+              "assemblyId": "text_style_Text Style",
+              "id": "2000591",
+              "quantity": 0,
+              "seller": "1",
+            },
+            Object {
+              "assemblyId": "text_style_Text Style",
+              "id": "2000592",
+              "quantity": 1,
+              "seller": "1",
+            },
+            Object {
+              "assemblyId": "engraving_Engraving",
+              "id": "2000586",
+              "options": Array [
+                Object {
+                  "assemblyId": "1-3-lines",
+                  "inputValues": Object {
+                    "Line 1": "First line",
+                    "Line 2": "Second line",
+                    "Line 3": "Third line",
+                  },
+                },
+              ],
+              "quantity": 1,
+              "seller": "1",
+            },
+          ],
+        }
+      `)
     })
 
     it('empty input values should result in empty options', () => {

--- a/react/modules/assemblyOptions.ts
+++ b/react/modules/assemblyOptions.ts
@@ -92,19 +92,32 @@ export function transformAssemblyOptions({
   // array with removed assemblies data to show in minicart optimistic preview
   const removed: CartRemovedOption[] = []
 
+  let assemblyInputValuesKeys: GroupId[] = Object.keys(inputValues)
+
   const assemblyItemsKeys: GroupId[] = Object.keys(assemblyOptionsItems)
 
   for (const groupId of assemblyItemsKeys) {
     const items = assemblyOptionsItems[groupId]
     for (const item of items) {
-      const childrenAddedData = item.children
-        ? transformAssemblyOptions({
-            assemblyOptionsItems: item.children,
-            inputValues: {},
-            parentPrice: item.price,
-            parentQuantity: item.quantity * parentQuantity,
-          })
-        : null
+      let childrenAddedData = null
+
+      if (item.children) {
+        const childInputValues: Record<GroupId, InputValue> = {}
+        for (const key in item.children) {
+          childInputValues[key] = inputValues[key]
+        }
+        const handledInputValues = Object.keys(childInputValues)
+        assemblyInputValuesKeys = assemblyInputValuesKeys.filter(
+          inputValueKey => handledInputValues.includes(inputValueKey)
+        )
+
+        childrenAddedData = transformAssemblyOptions({
+          assemblyOptionsItems: item.children,
+          inputValues: childInputValues,
+          parentPrice: item.price,
+          parentQuantity: item.quantity * parentQuantity,
+        })
+      }
 
       const {
         options: childrenOptions,
@@ -160,8 +173,6 @@ export function transformAssemblyOptions({
       }
     }
   }
-
-  const assemblyInputValuesKeys: GroupId[] = Object.keys(inputValues)
 
   for (const groupId of assemblyInputValuesKeys) {
     const inputValuesObject = inputValues[groupId] || {}


### PR DESCRIPTION
Same as https://github.com/vtex-apps/store-components/pull/806

#### What problem is this solving?

Fix input values when it's inside an assembly option.

#### How to test it?

1. Open https://breno--storecomponents.myvtex.com/custom-bell/p
2. Click Customize in "Bells add-ons 1-3 lines"
3. Click "Add 1-3-Lines"
4. Fill the inputs "Line 1", "Line 2", and "Line 3".
5. Click "Done"
6. Click "Add To Cart"
7. Go to cart page
8. Once in the Cart page open dev tools and type in the console:
`vtexjs.checkout.orderForm.items[2].assemblies`

It should return an object with the values input.

Compare it with master workspace which doesn't have this fix and the last step won't work.

#### Describe alternatives you've considered, if any.

We should refactor the Product Customizer solution. It does not provide enough info for this solution to be future proof. It will break if two products have the same input values for instance.

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

