### PR TITLE
Add `ean` to `addToCart` event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ean` to `addToCart` event.
 
 ## [0.13.5] - 2020-08-07
 ### Added

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -70,6 +70,7 @@ const adjustSkuItemForPixelEvent = (skuItem: CartItem) => {
 
   return {
     skuId: skuItem.id,
+    ean: skuItem.ean,
     variant: skuItem.variant,
     price: skuItem.price,
     name: skuItem.name,

--- a/react/__fixtures__/productContext.ts
+++ b/react/__fixtures__/productContext.ts
@@ -74,7 +74,7 @@ export const StarColorTop = {
         name: 'Red star',
         nameComplete: 'Top Star Color Shirt Red star',
         complementName: 'Tank top with star',
-        ean: '',
+        ean: '123456',
         referenceId: [
           {
             Key: 'RefId',
@@ -250,7 +250,7 @@ export const StarColorTop = {
         name: 'Magento',
         nameComplete: 'Top Star Color Shirt Magento',
         complementName: 'Tank top with star',
-        ean: '',
+        ean: '123456',
         referenceId: [
           {
             Key: 'RefId',
@@ -2594,7 +2594,7 @@ export const StarColorTop = {
     name: 'Red star',
     nameComplete: 'Top Star Color Shirt Red star',
     complementName: 'Tank top with star',
-    ean: '',
+    ean: '123456',
     referenceId: [
       {
         Key: 'RefId',

--- a/react/__tests__/Wrapper.test.tsx
+++ b/react/__tests__/Wrapper.test.tsx
@@ -127,6 +127,7 @@ describe('Wrapper component', () => {
       {
         index: 0,
         id: '2000564',
+        ean: '123456',
         productId: '2000024',
         quantity: 1,
         uniqueId: '',

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -319,6 +319,7 @@ describe('catalogToCart module', () => {
       {
         index: 0,
         id: '2000564',
+        ean: '123456',
         productId: '2000024',
         quantity: 1,
         uniqueId: '',

--- a/react/modules/catalogItemToCart.ts
+++ b/react/modules/catalogItemToCart.ts
@@ -8,6 +8,7 @@ import {
 export interface CartItem {
   detailUrl: string
   id: string
+  ean: string
   imageUrl: string
   index?: number
   listPrice: number
@@ -63,6 +64,7 @@ export function mapCatalogItemToCart({
     {
       index: 0,
       id: selectedItem.itemId,
+      ean: selectedItem.ean,
       productId: product.productId ?? '',
       quantity: selectedQuantity,
       uniqueId: '',


### PR DESCRIPTION
#### What problem is this solving?

Adds `ean` to the `addToCart` event

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/)

#### Screenshots or example usage:

1 - open the workspace
2 - add any item to the cart
3 - open console, type "pixelManagerEvents" and press enter
4 - open the results and check the `addToCart` event
5 - check that there is an `ean` field within `items`

![image](https://user-images.githubusercontent.com/8443580/91215178-8b2ded00-e6ea-11ea-90e0-403d15442c6d.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/4ayE7jjRuUBQk/giphy.gif)
