### PR TITLE
Add 'customPixelEventId' and 'addToCartFeedback' props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `customEventId` prop.
+- `customPixelEventId` prop.
 - `addToCartFeedback` prop.
 
 ## [0.15.1] - 2020-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customEventId` prop.
+- `addToCartFeedback` prop.
 
 ## [0.15.1] - 2020-09-02
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,8 +44,8 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastUrl`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |
 | `text` | `string` | Defines a custom text message to be displayed on the Add To Cart Button. | `Add to cart` *( automatic translation will be applied according to your store's default language)* | 
-| `unavailableText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button when a product is unavailable. | `Unavailable` *(automatic translation will be applied according to your store's default language)* | 
-
+| `unavailableText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button when a product is unavailable. | `Unavailable` *(automatic translation will be applied according to your store's default language)* |
+| `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the button upon user interaction. | `undefined`   |
 
 ## Customization
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -36,7 +36,7 @@ interface Props {
   unavailableText?: string
   productLink: ProductLink
   onClickBehavior: 'add-to-cart' | 'go-to-product-page' | 'ensure-sku-selection'
-  customEventId?: string
+  customPixelEventId?: string
   addToCartFeedback?: 'customEvent' | 'toast'
 }
 
@@ -105,7 +105,7 @@ function AddToCartButton(props: Props) {
     productLink,
     onClickBehavior,
     multipleAvailableSKUs,
-    customEventId,
+    customPixelEventId,
     addToCartFeedback,
   } = props
 
@@ -195,9 +195,9 @@ function AddToCartButton(props: Props) {
     const itemsAdded = addItem(skuItems, { ...utmParams, ...utmiParams })
     const pixelEventItems = skuItems.map(mapSkuItemForPixelEvent)
     const pixelEvent =
-      customEventId && addToCartFeedback === 'customEvent'
+      customPixelEventId && addToCartFeedback === 'customEvent'
         ? {
-            id: customEventId,
+            id: customPixelEventId,
             event: 'addToCart',
             items: pixelEventItems,
           }

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -10,10 +10,10 @@ interface Props {
   isOneClickBuy: boolean
   available: boolean
   disabled: boolean
-  customToastUrl: string
-  customOneClickBuyLink: string
+  customToastUrl?: string
+  customOneClickBuyLink?: string
   showToast: Function
-  selectedSeller: Seller | undefined
+  selectedSeller?: Seller
   text?: string
   unavailableText?: string
   onClickBehavior?:
@@ -21,6 +21,8 @@ interface Props {
     | 'go-to-product-page'
     | 'ensure-sku-selection'
   skuItems?: CartItem[]
+  customEventId?: string
+  addToCartFeedback?: 'toast' | 'customEvent'
 }
 
 function checkAvailability(
@@ -72,6 +74,8 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     selectedSeller,
     unavailableText,
     text,
+    customEventId,
+    addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
   } = props
   const productContext: ProductContextState = useProduct()
@@ -135,6 +139,8 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       productLink={productLink}
       onClickBehavior={onClickBehavior}
       multipleAvailableSKUs={multipleAvailableSKUs}
+      customEventId={customEventId}
+      addToCartFeedback={addToCartFeedback}
     />
   )
 })

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -21,7 +21,7 @@ interface Props {
     | 'go-to-product-page'
     | 'ensure-sku-selection'
   skuItems?: CartItem[]
-  customEventId?: string
+  customPixelEventId?: string
   addToCartFeedback?: 'toast' | 'customEvent'
 }
 
@@ -74,7 +74,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     selectedSeller,
     unavailableText,
     text,
-    customEventId,
+    customPixelEventId,
     addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
   } = props
@@ -139,7 +139,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       productLink={productLink}
       onClickBehavior={onClickBehavior}
       multipleAvailableSKUs={multipleAvailableSKUs}
-      customEventId={customEventId}
+      customPixelEventId={customPixelEventId}
       addToCartFeedback={addToCartFeedback}
     />
   )


### PR DESCRIPTION
#### What problem is this solving?

This enables users to control what kind of feedback should be triggered when a customer clicks in the `add-to-cart-button`, and adds a product to their minicart.

Also, `customEventId` enables other apps to listen for an `addToCart` event with this id. This enables all the linked PRs below to do their magic.

#### How to test it?

Go to [Workspace](https://customevents--storecomponents.myvtex.com/) and add some products to the cart. You should see the `minicart.v2` opening up and also a modal. Also, the toast we all know and love (I guess...) should not be shown.

#### Related to

- https://github.com/vtex/pixel-manager/pull/29
- https://github.com/vtex-apps/drawer/pull/34
- https://github.com/vtex-apps/minicart/pull/240
- https://github.com/vtex-apps/modal-layout/pull/38

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/xUOxeSXjqTCTzkq40w/giphy.gif)
