### PR TITLE
Use navigate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use navigate when redirecting to checkout
 
 ## [0.18.0] - 2020-09-16
 ### Removed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -115,7 +115,7 @@ function AddToCartButton(props: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const { addItem } = useOrderItems()
   const productContextDispatch = useProductDispatch()
-  const { rootPath = '', navigate } = useRuntime()
+  const { navigate } = useRuntime()
   const { url: checkoutURL, major } = useCheckoutURL()
   const { push } = usePixel()
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
@@ -140,7 +140,7 @@ function AddToCartButton(props: Props) {
   useEffect(() => {
     const currentTimers = timers.current
 
-    if (isFakeLoading) {
+    if (isFakeLoading && !isOneClickBuy) {
       currentTimers.loading = window.setTimeout(
         () => setFakeLoading(false),
         FAKE_LOADING_DURATION
@@ -205,22 +205,23 @@ function AddToCartButton(props: Props) {
     push(pixelEvent)
 
     if (isOneClickBuy) {
+      setFakeLoading(false)
+
       if (
         major > 0 &&
         (!customOneClickBuyLink || customOneClickBuyLink === checkoutURL)
       ) {
         navigate({ to: checkoutURL })
       } else {
-        window.location.assign(
-          `${rootPath}${customOneClickBuyLink ?? checkoutURL}`
-        )
+        navigate({ to: `${customOneClickBuyLink ?? checkoutURL}`, fallbackToWindowLocation: true })
       }
     }
 
-    addToCartFeedback === 'toast' &&
+    if (addToCartFeedback === 'toast' && !isOneClickBuy) {
       (timers.current.toast = window.setTimeout(() => {
         toastMessage({ success: true })
       }, FAKE_LOADING_DURATION))
+    }
 
     /* PWA */
     if (promptOnCustomEvent === 'addToCart' && showInstallPrompt) {

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -205,13 +205,11 @@ function AddToCartButton(props: Props) {
     push(pixelEvent)
 
     if (isOneClickBuy) {
-      setFakeLoading(false)
-
       if (
         major > 0 &&
         (!customOneClickBuyLink || customOneClickBuyLink === checkoutURL)
       ) {
-        navigate({ to: checkoutURL })
+        navigate({ to: checkoutURL, fallbackToWindowLocation: false })
       } else {
         navigate({
           to: `${customOneClickBuyLink ?? checkoutURL}`,

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -146,7 +146,7 @@ function AddToCartButton(props: Props) {
         FAKE_LOADING_DURATION
       )
     }
-  }, [isFakeLoading])
+  }, [isFakeLoading, isOneClickBuy])
 
   const resolveToastMessage = (success: boolean) => {
     if (!success) return translateMessage(messages.error)
@@ -213,14 +213,17 @@ function AddToCartButton(props: Props) {
       ) {
         navigate({ to: checkoutURL })
       } else {
-        navigate({ to: `${customOneClickBuyLink ?? checkoutURL}`, fallbackToWindowLocation: true })
+        navigate({
+          to: `${customOneClickBuyLink ?? checkoutURL}`,
+          fallbackToWindowLocation: true,
+        })
       }
     }
 
     if (addToCartFeedback === 'toast' && !isOneClickBuy) {
-      (timers.current.toast = window.setTimeout(() => {
+      timers.current.toast = window.setTimeout(() => {
         toastMessage({ success: true })
-      }, FAKE_LOADING_DURATION))
+      }, FAKE_LOADING_DURATION)
     }
 
     /* PWA */


### PR DESCRIPTION
#### What problem is this solving?

Use navigate when redirecting to checkout cart to permit adding the loading bar on top of the document. Also remove the "Item added to cart" toaster in this use case.

#### How to test it?

In the workspace try to add to cart and verify if everything is ok( with the redirect) and if the document has a loading bar in the process.

https://vitorflg--storecomponents.myvtex.com/

[Workspace](Link goes here!)

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

https://github.com/vtex-apps/render-runtime/pull/567
