### PR TITLE
Export `mapCatalogItemToCart` in react root folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Export `mapCatalogItemToCart` in react root folder.
+
 ## [0.19.0] - 2020-10-13
 ### Fixed
 - Use `navigate()` when redirecting to the checkout

--- a/react/mapCatalogItemToCart.ts
+++ b/react/mapCatalogItemToCart.ts
@@ -1,0 +1,3 @@
+import { mapCatalogItemToCart } from './modules/catalogItemToCart'
+
+export default mapCatalogItemToCart


### PR DESCRIPTION
#### What problem is this solving?

Export mapCatalogItemToCart so we can import and use this function.

![image](https://user-images.githubusercontent.com/49173685/96266887-92140600-0f9d-11eb-9040-a9c5858a6b3d.png)


