### PR TITLE
Add missing preventDefault call on handleAddToCart function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing `preventDefault` call on `handleAddToCart` function.
 
 ## [0.21.0] - 2021-01-04
 ### Added

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -169,6 +169,7 @@ function AddToCartButton(props: Props) {
   const handleAddToCart: React.MouseEventHandler = event => {
     if (onClickEventPropagation === 'disabled') {
       event.stopPropagation()
+      event.preventDefault()
     }
 
     setFakeLoading(true)


### PR DESCRIPTION
#### What problem is this solving?

Users would **always** be redirected to a product page in cases where the `add-to-cart-button` is placed inside a `product-summary`.

#### How to test it?

Add a product from the Shelf into the cart [here](https://victormiranda--storecomponents.myvtex.com/). You should not be redirected.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/LRVnPYqM8DLag/giphy.gif)
