### PR TITLE
added duration of toast

### DIFF
--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -30,7 +30,8 @@ interface Props {
   customToastUrl?: string
   customOneClickBuyLink?: string
   skuItems: CartItem[]
-  showToast: Function
+  showToast: Function,
+  toastDuration: number,
   allSkuVariationsSelected: boolean
   text?: string
   unavailableText?: string
@@ -43,6 +44,7 @@ interface Props {
 
 // We apply a fake loading to accidental consecutive clicks on the button
 const FAKE_LOADING_DURATION = 500
+const TOAST_DURATION = 5000
 
 const CSS_HANDLES = [
   'buttonText',
@@ -111,6 +113,7 @@ function AddToCartButton(props: Props) {
     customPixelEventId,
     addToCartFeedback,
     onClickEventPropagation = 'disabled',
+    toastDuration = TOAST_DURATION
   } = props
 
   const intl = useIntl()
@@ -163,7 +166,7 @@ function AddToCartButton(props: Props) {
       ? { label: translateMessage(messages.seeCart), href: customToastUrl }
       : undefined
 
-    showToast({ message, action })
+    showToast({ message, action, duration: toastDuration })
   }
 
   const handleAddToCart: React.MouseEventHandler = event => {

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -13,7 +13,8 @@ interface Props {
   disabled: boolean
   customToastUrl?: string
   customOneClickBuyLink?: string
-  showToast: Function
+  showToast: Function,
+  toastDuration: number,
   selectedSeller?: ProductTypes.Seller
   text?: string
   unavailableText?: string
@@ -80,6 +81,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
     onClickEventPropagation = 'disabled',
+    toastDuration,
   } = props
   const productContext = useProduct()
   const isEmptyContext = Object.keys(productContext ?? {}).length === 0
@@ -148,6 +150,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       multipleAvailableSKUs={multipleAvailableSKUs}
       customPixelEventId={customPixelEventId}
       addToCartFeedback={addToCartFeedback}
+      toastDuration={toastDuration}
     />
   )
 })


### PR DESCRIPTION
#### What problem is this solving?

We need to customize the duration of the toast that appears on successfully adding new product into the card. We thus added a new prop `toastDuration` which would be a number representing milliseconds. This will be the duration of the toast appearing on the page.

#### How to test it?

Add a `toastDuration` prop and this should be the exact duration of it appearing in the page. If you do not add this prop, the default will be 5000.

#### Screenshots or example usage:

<img width="1135" alt="Screenshot 2021-02-26 at 17 52 09" src="https://user-images.githubusercontent.com/44602686/109329853-606c4f00-785b-11eb-894f-4d53bb6f7a62.png">
