### PR TITLE
CHK-609: Contextual pipeline for adding/updating items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Property `allowedOutdatedData` is defined and passed to addItem mutation.
+
 ## [0.23.1] - 2021-03-30
 ### Fixed
 - Use `sellerDefault` as default seller selection and fallback to first seller.

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -69,7 +69,9 @@ const messages = defineMessages({
   },
 })
 
-const allowedOutdatedData =['paymentData']
+const options = {
+  allowedOutdatedData: ['paymentData']
+}
 
 const mapSkuItemForPixelEvent = (skuItem: CartItem) => {
   // Changes this `/Apparel & Accessories/Clothing/Tops/`
@@ -195,7 +197,7 @@ function AddToCartButton(props: Props) {
       return
     }
 
-    addItem(skuItems, { ...utmParams, ...utmiParams }, undefined, allowedOutdatedData)
+    addItem(skuItems, { ...utmParams, ...utmiParams }, undefined, options)
 
     const pixelEventItems = skuItems.map(mapSkuItemForPixelEvent)
     const pixelEvent =

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -69,6 +69,8 @@ const messages = defineMessages({
   },
 })
 
+const allowedOutdatedData =['paymentData']
+
 const mapSkuItemForPixelEvent = (skuItem: CartItem) => {
   // Changes this `/Apparel & Accessories/Clothing/Tops/`
   // to this `Apparel & Accessories/Clothing/Tops`
@@ -193,7 +195,7 @@ function AddToCartButton(props: Props) {
       return
     }
 
-    addItem(skuItems, { ...utmParams, ...utmiParams })
+    addItem(skuItems, { ...utmParams, ...utmiParams }, undefined, allowedOutdatedData)
 
     const pixelEventItems = skuItems.map(mapSkuItemForPixelEvent)
     const pixelEvent =

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -70,7 +70,7 @@ const messages = defineMessages({
 })
 
 const options = {
-  allowedOutdatedData: ['paymentData']
+  allowedOutdatedData: ['paymentData'],
 }
 
 const mapSkuItemForPixelEvent = (skuItem: CartItem) => {
@@ -120,7 +120,7 @@ function AddToCartButton(props: Props) {
 
   const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
-  const { addItem } = useOrderItems()
+  const { addItems } = useOrderItems()
   const productContextDispatch = useProductDispatch()
   const { rootPath = '', navigate } = useRuntime()
   const { url: checkoutURL, major } = Utils.useCheckoutURL()
@@ -197,7 +197,10 @@ function AddToCartButton(props: Props) {
       return
     }
 
-    addItem(skuItems, { ...utmParams, ...utmiParams }, undefined, options)
+    addItems(skuItems, {
+      marketingData: { ...utmParams, ...utmiParams },
+      ...options,
+    })
 
     const pixelEventItems = skuItems.map(mapSkuItemForPixelEvent)
     const pixelEvent =

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -77,6 +77,8 @@ const mockProductLink = {
   productId: '2000024',
 }
 
+const mockAllowedOutdatedData = ['paymentData']
+
 const mockAddItem = jest.fn()
 const mockPixelEventPush = jest.fn()
 const mockNavigate = jest.fn()
@@ -232,7 +234,7 @@ describe('AddToCartButton component', () => {
       }
     })
 
-    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData)
+    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData, undefined, mockAllowedOutdatedData)
   })
 
   it('should pass correct marketing data info to addItem function', () => {
@@ -262,7 +264,7 @@ describe('AddToCartButton component', () => {
       }
     })
 
-    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData)
+    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData, undefined, mockAllowedOutdatedData)
   })
 
   it('should sent correct information about SKU items to pixel event', () => {

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -78,7 +78,7 @@ const mockProductLink = {
 }
 
 const mockAllowedOutdatedData = {
-  allowedOutdatedData: ['paymentData']
+  allowedOutdatedData: ['paymentData'],
 }
 
 const mockAddItem = jest.fn()
@@ -102,7 +102,7 @@ jest.mock('../hooks/useMarketingSessionParams', () => {
 
 jest.mock('vtex.order-items/OrderItems', () => ({
   useOrderItems: () => ({
-    addItem: mockAddItem,
+    addItems: mockAddItem,
   }),
 }))
 
@@ -236,7 +236,10 @@ describe('AddToCartButton component', () => {
       }
     })
 
-    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData, undefined, mockAllowedOutdatedData)
+    expect(mockAddItem).toBeCalledWith(mockSKUItems, {
+      marketingData: mockMarketingData,
+      ...mockAllowedOutdatedData,
+    })
   })
 
   it('should pass correct marketing data info to addItem function', () => {
@@ -266,7 +269,10 @@ describe('AddToCartButton component', () => {
       }
     })
 
-    expect(mockAddItem).toBeCalledWith(mockSKUItems, mockMarketingData, undefined, mockAllowedOutdatedData)
+    expect(mockAddItem).toBeCalledWith(mockSKUItems, {
+      marketingData: mockMarketingData,
+      ...mockAllowedOutdatedData,
+    })
   })
 
   it('should sent correct information about SKU items to pixel event', () => {

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -77,7 +77,9 @@ const mockProductLink = {
   productId: '2000024',
 }
 
-const mockAllowedOutdatedData = ['paymentData']
+const mockAllowedOutdatedData = {
+  allowedOutdatedData: ['paymentData']
+}
 
 const mockAddItem = jest.fn()
 const mockPixelEventPush = jest.fn()


### PR DESCRIPTION
#### What problem is this solving?

Adding the new parameter that allow the contextual pipeline execution

#### How to test it?

Run [this](https://contextualpipeline--checkoutio.myvtex.com/_v/private/vtex.order-items@0.11.0/graphiql/v1?query=mutation%20%7B%0A%20%20updateItems(orderItems%3A%20%7B%0A%20%20%20%20index%3A%200%2C%0A%20%20%20%20quantity%3A%202%0A%20%20%7D%2C%0A%20%20allowedOutdatedData%3A%20%5B%22paymentData%22%5D)%7B%0A%20%20%20%20value%0A%20%20%20%20paymentData%7B%0A%20%20%20%20%20%20installmentOptions%7B%0A%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) mutation. Add a new item to the cart [here](https://contextualpipeline--checkoutio.myvtex.com/). Run the mutation and guarantee the `value` fields in `installmentOptions` don't alter, while the `value` field in data does.

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

#### Related to / Depends on

[order-items](https://github.com/vtex-apps/order-items/pull/41)

#### How does this PR make you feel? [:link:](http://giphy.com/)
