### PR TITLE
Fix autocomplete behavior on touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add to cart from mobile autocomplete.
+
 ## [0.26.0] - 2021-05-05
 
 ### Added 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -291,6 +291,7 @@ function AddToCartButton(props: Props) {
       isLoading={isFakeLoading}
       disabled={disabled || !available}
       onClick={handleClick}
+      onTouchEnd={handleClick}
     >
       {available ? availableButtonContent : unavailableButtonContent}
     </Button>

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -285,15 +285,20 @@ function AddToCartButton(props: Props) {
     </span>
   )
 
+  const touchDevice =
+    'ontouchstart' in window ||
+    (typeof navigator !== 'undefined' &&
+      (navigator?.maxTouchPoints || navigator?.msMaxTouchPoints))
+
   const ButtonWithLabel = (
     <Button
       block
       isLoading={isFakeLoading}
       disabled={disabled || !available}
-      onClick={handleClick}
+      onClick={!touchDevice && handleClick}
       // onTouchEnd is necessary because when using the button on mobile (with touch)
       // the `preventDefault` is not mapped correctly in `onClick` and closes the autocomplete
-      onTouchEnd={handleClick}
+      onTouchEnd={touchDevice && handleClick}
     >
       {available ? availableButtonContent : unavailableButtonContent}
     </Button>

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -291,6 +291,8 @@ function AddToCartButton(props: Props) {
       isLoading={isFakeLoading}
       disabled={disabled || !available}
       onClick={handleClick}
+      // onTouchEnd is necessary because when using the button on mobile (with touch)
+      // the `preventDefault` is not mapped correctly in `onClick` and closes the autocomplete
       onTouchEnd={handleClick}
     >
       {available ? availableButtonContent : unavailableButtonContent}


### PR DESCRIPTION
#### What problem is this solving?

when clicking on the add to cart button on the mobile autocomplete, the autocomplete closes. 
so the user is unable to include more items directly in the autocomplete

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--gigadigital.myvtex.com/)
- in the autocomplete, type a term and click the add to cart button of the suggested product
- the autocomplete should not close

#### Screenshots or example usage:

https://user-images.githubusercontent.com/20840671/116931016-e11e4180-ac36-11eb-8990-b8555a99c0ef.mp4

https://user-images.githubusercontent.com/20840671/116931025-e2e80500-ac36-11eb-86fc-4d93a7e30c85.mp4

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->
https://github.com/vtex/styleguide/pull/1381

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
