### PR TITLE
Check position to consider as scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Check position on the screen to consider as scroll/click.
+
 ## [0.26.2] - 2021-05-20
 
 ### Fixed

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -285,28 +285,28 @@ function AddToCartButton(props: Props) {
     </span>
   )
 
-  let touchMoved = false
-  let position = window.pageYOffset
+  const touchMoved = useRef(false)
+  const position = useRef(window.pageYOffset)
   const touchDevice =
     'ontouchstart' in window ||
     (typeof navigator !== 'undefined' &&
       (navigator?.maxTouchPoints || navigator?.msMaxTouchPoints))
 
   const handleTouchStart = (event: React.TouchEvent) => {
-    touchMoved = false
-    position = window.pageYOffset
+    touchMoved.current = false
+    position.current = window.pageYOffset
     event.stopPropagation()
   }
 
   const handleTouchMove = (event: React.TouchEvent) => {
-    if (Math.abs(window.pageYOffset - position) > 10) {
-      touchMoved = true
+    if (Math.abs(window.pageYOffset - position.current) > 10) {
+      touchMoved.current = true
     }
     event.stopPropagation()
   }
 
   const handleTouchEnd = (event: React.MouseEvent) => {
-    if (touchMoved) {
+    if (touchMoved.current) {
       return
     }
     handleClick(event)

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -286,6 +286,7 @@ function AddToCartButton(props: Props) {
   )
 
   let touchMoved = false
+  let position = window.pageYOffset
   const touchDevice =
     'ontouchstart' in window ||
     (typeof navigator !== 'undefined' &&
@@ -293,11 +294,14 @@ function AddToCartButton(props: Props) {
 
   const handleTouchStart = (event: React.TouchEvent) => {
     touchMoved = false
+    position = window.pageYOffset
     event.preventDefault()
   }
 
   const handleTouchMove = (event: React.TouchEvent) => {
-    touchMoved = true
+    if (Math.abs(window.pageYOffset - position) > 10) {
+      touchMoved = true
+    }
     event.preventDefault()
   }
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -295,14 +295,14 @@ function AddToCartButton(props: Props) {
   const handleTouchStart = (event: React.TouchEvent) => {
     touchMoved = false
     position = window.pageYOffset
-    event.preventDefault()
+    event.stopPropagation()
   }
 
   const handleTouchMove = (event: React.TouchEvent) => {
     if (Math.abs(window.pageYOffset - position) > 10) {
       touchMoved = true
     }
-    event.preventDefault()
+    event.stopPropagation()
   }
 
   const handleTouchEnd = (event: React.MouseEvent) => {


### PR DESCRIPTION
#### What problem is this solving?

when trying to add the product to the cart via mobile, it was difficult to perform the action because the user needs to click and release the button without moving his finger on the screen. thus, if the user moved his finger without even realizing it, it gave the impression that the button was not clickable.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://thalyta1--gigadigital.myvtex.com/guarana?_q=guarana&map=ft)
[After](https://thalyta--gigadigital.myvtex.com/guarana?_q=guarana&map=ft)
[Arcaplanet](https://thalyta--arcaplanet.myvtex.com/monge)

in the mobile (preferably using a cell phone where it's easier to see the behavior) try to click on the add to cart button, and before releasing the button, move your finger a little. check that after that the button is still clicked.
in addition, make sure that when scrolling over the button (without the purpose of clicking on it) the button remains unclicked.

#### Screenshots or example usage:


https://user-images.githubusercontent.com/20840671/119353099-da547e80-bc78-11eb-8b76-929eb68e7b34.mp4

https://user-images.githubusercontent.com/20840671/119353108-dc1e4200-bc78-11eb-9379-6be49696d27d.mp4


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
