### PR TITLE
fix: isOneClickBuy button only redirects users after confirmation that the item was added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Now, when `isOneClickBuy` is enabled, the users are only redirected when there's confirmation that the item was added to the cart
+
 ## [0.26.5] - 2021-06-17
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes a problem where users would be redirected to the checkout page before the item was properly added to the cart. On the checkout, users couldn't see the item they just added. This happened especially on the Safari browser.

#### How to test it?

Click the buy button on the home shelf or on the product page.

[Workspace](https://icarovtex--pilotoqro.myvtex.com/)


#### Related to / Depends on

Depends on [https://github.com/vtex/order-items/pull/18](https://github.com/vtex/order-items/pull/18) 

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xUOxeSXjqTCTzkq40w/giphy-downsized.gif)
