### PR TITLE
fix: preventDefault and stopPropagation only triggering when variatio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- stopPropagation and preventDefault removed from `handleAddToCart` and added into `handleClick` in `AddToCartButton.tsx` to trigger too when no variation were selected.
+
+
 ## [0.26.7] - 2021-08-03
 
 ### Added

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -176,12 +176,7 @@ function AddToCartButton(props: Props) {
     showToast({ message, action })
   }
 
-  const handleAddToCart = async (event: React.MouseEvent) => {
-    if (onClickEventPropagation === 'disabled') {
-      event.stopPropagation()
-      event.preventDefault()
-    }
-
+  const handleAddToCart = async () => {
     setFakeLoading(true)
 
     const productLinkIsValid = Boolean(
@@ -257,8 +252,13 @@ function AddToCartButton(props: Props) {
       })
     }
 
+    if (onClickEventPropagation === 'disabled') {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+
     if (allSkuVariationsSelected) {
-      handleAddToCart(e)
+      handleAddToCart()
     }
   }
 


### PR DESCRIPTION
fix: preventDefault and stopPropagation only triggering when variation is selected

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

preventDefault and stopPropagation were only being triggered when variation is selected, just added into handleClick instead of handleAddToCart to solve it, and now, is being triggered if there's no variation selected too

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Go to a search page or any product summary with sku selector with no variations selected and try to add to cart with the prop onClickEventPropagation set as "disabled"

Before
[Workspace](https://ticket400798--batacl.myvtex.com/infantil/nino/zapatillas)

After
[Workspace](https://iespinoza--batacl.myvtex.com/infantil/nino/zapatillas)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

![image](https://user-images.githubusercontent.com/13649073/129089468-4abac5f5-abe7-4d41-9157-473dc394ffd3.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/TLDK7PnZ4w8GMxyEmq/giphy.gif)
