### PR TITLE
fix: format on the available and unavailable content on the button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- Add formatedIOMessage on the AddtoCartButton to format the available and the unavailable content and also out the import on the file, this allows the format to urdu texts to be added.
+
 ## [0.26.8] - 2021-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed 
 
-- Add formatedIOMessage on the AddtoCartButton to format the available and the unavailable content and also out the import on the file, this allows the format to urdu texts to be added.
+- Available and unavailable content text wasn't being translated. So, formatedIOMessage was added to AddtoCartButton.
 
 ## [0.26.8] - 2021-08-19
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -13,6 +13,7 @@ import { usePixel } from 'vtex.pixel-manager'
 import { useProductDispatch } from 'vtex.product-context'
 import { usePWA } from 'vtex.store-resources/PWAContext'
 import { useOrderItems } from 'vtex.order-items/OrderItems'
+import { formatIOMessage } from 'vtex.native-types'
 
 import { CartItem } from './modules/catalogItemToCart'
 import useMarketingSessionParams from './hooks/useMarketingSessionParams'
@@ -206,14 +207,14 @@ function AddToCartButton(props: Props) {
     const pixelEvent =
       customPixelEventId && addToCartFeedback === 'customEvent'
         ? {
-            id: customPixelEventId,
-            event: 'addToCart',
-            items: pixelEventItems,
-          }
+          id: customPixelEventId,
+          event: 'addToCart',
+          items: pixelEventItems,
+        }
         : {
-            event: 'addToCart',
-            items: pixelEventItems,
-          }
+          event: 'addToCart',
+          items: pixelEventItems,
+        }
 
     // @ts-expect-error the event is not typed in pixel-manager
     push(pixelEvent)
@@ -268,7 +269,9 @@ function AddToCartButton(props: Props) {
   const availableButtonContent = (
     <div className={`${handles.buttonDataContainer} flex justify-center`}>
       {text ? (
-        <span className={handles.buttonText}>{text}</span>
+        <span className={handles.buttonText}>
+          {formatIOMessage({ id: text, intl })}
+        </span>
       ) : (
         <FormattedMessage id="store/add-to-cart.add-to-cart">
           {message => <span className={handles.buttonText}>{message}</span>}
@@ -278,7 +281,9 @@ function AddToCartButton(props: Props) {
   )
 
   const unavailableButtonContent = unavailableText ? (
-    <span className={handles.buttonText}>{unavailableText}</span>
+    <span className={handles.buttonText}>
+      {formatIOMessage({ id: unavailableText, intl })}
+    </span>
   ) : (
     <FormattedMessage id="store/add-to-cart.label-unavailable">
       {message => <span className={handles.buttonText}>{message}</span>}

--- a/react/__mocks__/vtex.native-types/index.tsx
+++ b/react/__mocks__/vtex.native-types/index.tsx
@@ -1,0 +1,1 @@
+export const formatIOMessage = ({ id }: { id: string }) => id


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

[Workspace](https://rfonseca--unileverb2b.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49077396/130646581-5aed97f1-b83a-4bea-8088-d7d14d184b10.png)
![image](https://user-images.githubusercontent.com/49077396/130646859-f01b3997-236e-4fec-9a36-738accd7b1c4.png)


#### Describe alternatives you've considered, if any.

I Don't think it have one

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/jrutBd1N7ZhsINAPzs/giphy.gif?cid=ecf05e47ptm5j9oybs0s806d3o141tzvufcoicoczhxczgeq&rid=giphy.gif&ct=g)
