### PR TITLE
Feature/add gclid to marketing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gclid` to marketing data sent to orderForm
 
 ## [0.26.12] - 2021-08-27
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -134,7 +134,7 @@ function AddToCartButton(props: Props) {
   const { push } = usePixel()
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings
-  const { utmParams, utmiParams } = useMarketingSessionParams()
+  const { utmParams, utmiParams, googleParams } = useMarketingSessionParams()
   const [isFakeLoading, setFakeLoading] = useState(false)
   const translateMessage = (message: MessageDescriptor) =>
     intl.formatMessage(message)
@@ -200,7 +200,7 @@ function AddToCartButton(props: Props) {
     }
 
     const addItemsPromise = addItems(skuItems, {
-      marketingData: { ...utmParams, ...utmiParams },
+      marketingData: { ...utmParams, ...utmiParams, ...googleParams },
       ...options,
     })
 

--- a/react/__tests__/hooks.test.tsx
+++ b/react/__tests__/hooks.test.tsx
@@ -31,7 +31,11 @@ describe('useMarketingSessionParams', () => {
       await wait(1)
     })
 
-    expect(result.current).toEqual({ utmParams: {}, utmiParams: {} })
+    expect(result.current).toEqual({
+      googleParams: {},
+      utmParams: {},
+      utmiParams: {},
+    })
   })
 
   it('should return empty objects if sessionPromise is nullish', async () => {
@@ -46,7 +50,11 @@ describe('useMarketingSessionParams', () => {
       await wait(1)
     })
 
-    expect(result.current).toEqual({ utmParams: {}, utmiParams: {} })
+    expect(result.current).toEqual({
+      googleParams: {},
+      utmParams: {},
+      utmiParams: {},
+    })
   })
 
   it('should return empty strings for utmParams if there are no utm fields', async () => {
@@ -62,6 +70,9 @@ describe('useMarketingSessionParams', () => {
     })
 
     expect(result.current).toEqual({
+      googleParams: {
+        gclid: '',
+      },
       utmParams: {
         utmSource: '',
         utmMedium: '',
@@ -88,6 +99,9 @@ describe('useMarketingSessionParams', () => {
     })
 
     expect(result.current).toEqual({
+      googleParams: {
+        gclid: '',
+      },
       utmParams: {
         utmSource: 'test_utm_field',
         utmMedium: 'test_utm_field',
@@ -114,6 +128,9 @@ describe('useMarketingSessionParams', () => {
     })
 
     expect(result.current).toEqual({
+      googleParams: {
+        gclid: '',
+      },
       utmParams: {
         utmSource: 'test_utm_field',
         utmMedium: 'test_utm_field',

--- a/react/hooks/useMarketingSessionParams.ts
+++ b/react/hooks/useMarketingSessionParams.ts
@@ -7,6 +7,7 @@ type PublicSessionField =
   | 'utmi_cp'
   | 'utmi_p'
   | 'utmi_pc'
+  | 'gclid'
 
 interface SessionPromiseFieldValue {
   value: string
@@ -22,6 +23,10 @@ interface UtmiParams {
   utmiCampaign?: string
   utmiPage?: string
   utmiPart?: string
+}
+
+interface GoogleParams {
+  gclid?: string
 }
 
 interface SessionPromiseResponse {
@@ -66,6 +71,12 @@ const getUtmiParams = (
   utmiCampaign: publicFields.utmi_cp?.value ?? '',
 })
 
+const getGoogleParams = (
+  publicFields: Record<PublicSessionField, SessionPromiseFieldValue>
+) => ({
+  gclid: publicFields.gclid?.value ?? '',
+})
+
 const getSessionPromiseFromWindow = () => {
   const runtimeSessionPromise = (window as Window & {
     ['__RENDER_8_SESSION__']?: {
@@ -79,6 +90,7 @@ const getSessionPromiseFromWindow = () => {
 const useMarketingSessionParams = () => {
   const [utmParams, setUtmParams] = useState<UtmParams>({})
   const [utmiParams, setUtmiParams] = useState<UtmiParams>({})
+  const [googleParams, setGoogleParams] = useState<GoogleParams>({})
 
   useEffect(() => {
     getSessionPromiseFromWindow()
@@ -98,13 +110,19 @@ const useMarketingSessionParams = () => {
             publicFields as Record<PublicSessionField, SessionPromiseFieldValue>
           )
         )
+
+        setGoogleParams(
+          getGoogleParams(
+            publicFields as Record<PublicSessionField, SessionPromiseFieldValue>
+          )
+        )
       })
       .catch(() => {
         // Do nothing
       })
   }, [])
 
-  return { utmParams, utmiParams }
+  return { utmParams, utmiParams, googleParams }
 }
 
 export default useMarketingSessionParams


### PR DESCRIPTION
#### What problem is this solving?

Currently, a store's revenue cannot be linked to a Google Adwords campaign because it missed the `gclid` when sending the orderPlaced data to GTM. This PR adds `gclid` to the marketing data sent to the orderForm. It gets it from the session, the same way as it gets the utm parameters.

#### How to test it?

**it can't be tested yet, thus it's blocked**
Add a product to the cart. The orderForm on the local storage should now have a `gclid` attribute with the same value as the one on the URL.

[Workspace](https://icaro--storecomponents.myvtex.com/?gclid=testeidgoogle)

#### Related to / Depends on

This PR is blocked until vcs.checkout supports `gclid`.

Depends on:

https://github.com/vtex-apps/checkout-resources/pull/87
https://github.com/vtex-apps/checkout-graphql/pull/154
https://github.com/vtex-apps/render-session/pull/40

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/qzmjxMUa5L6GA/giphy.gif?cid=ecf05e473w61uuhkm5bjlzmmuim4m31mdrbn1r962s9flr0t&rid=giphy.gif&ct=g)
