### PR TITLE
Add props to change message add to cart success

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 | `text` | `string` | Defines a custom text message to be displayed on the Add To Cart Button. | `Add to cart` *( automatic translation will be applied according to your store's default language)* |
 | `unavailableText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button when a product is unavailable. | `Unavailable` *(automatic translation will be applied according to your store's default language)* |
 | `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the button upon user interaction. | `undefined`   |
-| `messageAddToCartSucess` | `string` | Defines a custom text message to be displayed inside Toast when add products to cart. | `store/add-to-cart.success` *( automatic translation will be applied according to your store's default
+| `messageAddToCartSucess` | `string` | Defines a custom text message to be displayed inside Toast when add products to cart. | `store/add-to-cart.success`  *(automatic translation will be applied according to your store's default language)* |
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-📢 Use this project, [contribute](https://github.com/vtex-apps/add-to-cart-button) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion). 
+📢 Use this project, [contribute](https://github.com/vtex-apps/add-to-cart-button) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
 # Add To Cart Button
 
@@ -6,7 +6,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-The `add-to-cart-button` is a block responsible for adding products in the [Minicart](https://vtex.io/docs/components/all/vtex.minicart/) (`minicart.v2`). 
+The `add-to-cart-button` is a block responsible for adding products in the [Minicart](https://vtex.io/docs/components/all/vtex.minicart/) (`minicart.v2`).
 
 ![image](https://user-images.githubusercontent.com/284515/70233985-69e13700-173e-11ea-91f7-6675a6a0e73b.png)
 
@@ -44,10 +44,10 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 | `isOneClickBuy`         | `boolean` | Whether the user should be redirected to the checkout page (`true`) or not (`false`) when the Add To Cart Button is clicked on.  | `false`              |
 | `customOneClickBuyLink` | `string`  | Defines the link to where users will be redirected when the Add To Cart Button is clicked on and the `isOneClickBuy` prop is set to `true`. | `/checkout/#/cart` |
 | `customToastUrl`        | `string`  | Defines the link to where users will be redirected when the Toast (pop-up notification displayed when adding an item to the minicart) is clicked on.  | `/checkout/#/cart`   |
-| `text` | `string` | Defines a custom text message to be displayed on the Add To Cart Button. | `Add to cart` *( automatic translation will be applied according to your store's default language)* | 
+| `text` | `string` | Defines a custom text message to be displayed on the Add To Cart Button. | `Add to cart` *( automatic translation will be applied according to your store's default language)* |
 | `unavailableText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button when a product is unavailable. | `Unavailable` *(automatic translation will be applied according to your store's default language)* |
 | `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the button upon user interaction. | `undefined`   |
-
+| `messageAddToCartSucess` | `string` | Defines a custom text message to be displayed inside Toast when add products to cart. | `store/add-to-cart.success` *( automatic translation will be applied according to your store's default
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -40,7 +40,7 @@ interface Props {
   addToCartFeedback?: 'customEvent' | 'toast'
   onClickEventPropagation: 'disabled' | 'enabled'
   isLoading?: boolean,
-  messageAddToCartSucess?: string
+  messageAddToCartSuccess?: string
 }
 
 // We apply a fake loading to accidental consecutive clicks on the button
@@ -124,7 +124,7 @@ function AddToCartButton(props: Props) {
     addToCartFeedback,
     onClickEventPropagation = 'disabled',
     isLoading,
-    messageAddToCartSucess
+    messageAddToCartSuccess
   } = props
 
   const intl = useIntl()
@@ -171,7 +171,7 @@ function AddToCartButton(props: Props) {
 
   const toastMessage = ({ success }: { success: boolean }) => {
 
-    const message = messageAddToCartSucess ?? resolveToastMessage(success)
+    const message = messageAddToCartSuccess ?? resolveToastMessage(success)
 
     const action = success
       ? { label: translateMessage(messages.seeCart), href: customToastUrl }

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -166,7 +166,6 @@ function AddToCartButton(props: Props) {
 
   const resolveToastMessage = (success: boolean) => {
     if (!success) return translateMessage(messages.error)
-    console.log(success, 'success');
     return translateMessage(messages.success)
   }
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -39,7 +39,8 @@ interface Props {
   customPixelEventId?: string
   addToCartFeedback?: 'customEvent' | 'toast'
   onClickEventPropagation: 'disabled' | 'enabled'
-  isLoading?: boolean
+  isLoading?: boolean,
+  messageAddToCartSucess?: string
 }
 
 // We apply a fake loading to accidental consecutive clicks on the button
@@ -123,6 +124,7 @@ function AddToCartButton(props: Props) {
     addToCartFeedback,
     onClickEventPropagation = 'disabled',
     isLoading,
+    messageAddToCartSucess
   } = props
 
   const intl = useIntl()
@@ -164,12 +166,13 @@ function AddToCartButton(props: Props) {
 
   const resolveToastMessage = (success: boolean) => {
     if (!success) return translateMessage(messages.error)
-
+    console.log(success, 'success');
     return translateMessage(messages.success)
   }
 
   const toastMessage = ({ success }: { success: boolean }) => {
-    const message = resolveToastMessage(success)
+
+    const message = messageAddToCartSucess ?? resolveToastMessage(success)
 
     const action = success
       ? { label: translateMessage(messages.seeCart), href: customToastUrl }

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -25,7 +25,7 @@ interface Props {
   skuItems?: CartItem[]
   customPixelEventId?: string
   addToCartFeedback?: 'toast' | 'customEvent',
-  messageAddToCartSucess?: string
+  messageAddToCartSuccess?: string
 }
 
 function checkAvailability(
@@ -95,7 +95,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
     onClickEventPropagation = 'disabled',
-    messageAddToCartSucess
+    messageAddToCartSuccess
   } = props
   const productContext = useProduct()
   const isEmptyContext = Object.keys(productContext ?? {}).length === 0
@@ -163,7 +163,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       multipleAvailableSKUs={multipleAvailableSKUs}
       customPixelEventId={customPixelEventId}
       addToCartFeedback={addToCartFeedback}
-      messageAddToCartSucess={messageAddToCartSucess}
+      messageAddToCartSuccess={messageAddToCartSuccess}
     />
   )
 })

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -24,7 +24,8 @@ interface Props {
   onClickEventPropagation?: 'disabled' | 'enabled'
   skuItems?: CartItem[]
   customPixelEventId?: string
-  addToCartFeedback?: 'toast' | 'customEvent'
+  addToCartFeedback?: 'toast' | 'customEvent',
+  messageAddToCartSucess?: string
 }
 
 function checkAvailability(
@@ -94,6 +95,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
     onClickEventPropagation = 'disabled',
+    messageAddToCartSucess
   } = props
   const productContext = useProduct()
   const isEmptyContext = Object.keys(productContext ?? {}).length === 0
@@ -161,6 +163,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       multipleAvailableSKUs={multipleAvailableSKUs}
       customPixelEventId={customPixelEventId}
       addToCartFeedback={addToCartFeedback}
+      messageAddToCartSucess={messageAddToCartSucess}
     />
   )
 })


### PR DESCRIPTION
#### What problem is this solving?

My client wants change the message Artigo adicionado ao carrinho for Produto adicionado ao carrinho. So, I did an props to change this in "add-to-cart-button"

#### How to test it?
Add props  "messageAddToCartSuccess" in "add-to-cart-button" block
  "add-to-cart-button": {
    "props": {
      "text": "comprar",
      "messageAddToCartSuccess": "Produto adicionado ao carrinho"
    }
  }

[Workspace](https://ms0216597produtoadicionado--pandorajoias.myvtex.com/)

#### Screenshots or example usage:
before
https://nimb.ws/CHYP9v

after
https://nimb.ws/sh30UR


#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/13k4VSc3ngLPUY/giphy.gif)
