### PR TITLE
added prop to be able to change the button text if the onClickBehavior prop is ensure-sku-selection or go-to-product-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+
+- goToProductPageText prop
 
 ## [0.26.13] - 2021-09-24
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ The `add-to-cart-button` is a block responsible for adding products in the [Mini
 | `text` | `string` | Defines a custom text message to be displayed on the Add To Cart Button. | `Add to cart` *( automatic translation will be applied according to your store's default language)* | 
 | `unavailableText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button when a product is unavailable. | `Unavailable` *(automatic translation will be applied according to your store's default language)* |
 | `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the button upon user interaction. | `undefined`   |
+| `goToProductPageText` | `string` | Defines a custom text message to be displayed on the Add To Cart Button if onClickBehavior prop is `go-to-product-page` or `ensure-sku-selection`. | `undefined` | 
 
 ## Customization
 

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react'
-import { useProduct } from 'vtex.product-context'
 import type { ProductTypes } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { withToast } from 'vtex.styleguide'
-
 import AddToCartButton from './AddToCartButton'
-import { mapCatalogItemToCart, CartItem } from './modules/catalogItemToCart'
 import { AssemblyOptions } from './modules/assemblyOptions'
+import { CartItem, mapCatalogItemToCart } from './modules/catalogItemToCart'
+
 
 interface Props {
   isOneClickBuy: boolean
@@ -25,6 +25,7 @@ interface Props {
   skuItems?: CartItem[]
   customPixelEventId?: string
   addToCartFeedback?: 'toast' | 'customEvent'
+  goToProductPageText?: string
 }
 
 function checkAvailability(
@@ -94,6 +95,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
     addToCartFeedback = 'toast',
     onClickBehavior = 'add-to-cart',
     onClickEventPropagation = 'disabled',
+    goToProductPageText,
   } = props
   const productContext = useProduct()
   const isEmptyContext = Object.keys(productContext ?? {}).length === 0
@@ -161,6 +163,7 @@ const Wrapper = withToast(function Wrapper(props: Props) {
       multipleAvailableSKUs={multipleAvailableSKUs}
       customPixelEventId={customPixelEventId}
       addToCartFeedback={addToCartFeedback}
+      goToProductPageText={goToProductPageText}
     />
   )
 })


### PR DESCRIPTION
#### What problem is this solving?
Changing the button text if the onClickBehavior prop is ensure-sku-selection or go-to-product-page
<!--- What is the motivation and context for this change? -->
One of our customers in Romania wants different texts on the button if the product has multiple skus that can be selected

#### How to test it?

[Workspace](https://anca--yachttng.myvtex.com/)

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/23127304/150519972-a7740ae5-c739-4466-b272-c42089871713.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/10UeedrT5MIfPG/giphy.gif)