### PR TITLE
Add German translations to make it available across Admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- German translation.
+
 ## [0.29.0] - 2023-01-02
 
 ### Added

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1,0 +1,13 @@
+{
+  "store/add-to-cart.success": "Artikel in den Warenkorb gelegt",
+  "store/add-to-cart.failure": "Etwas ging schief und der Artikel wurde nicht in Ihren Warenkorb gelegt!",
+  "store/add-to-cart.see-cart": "Warenkorb anzeigen",
+  "store/add-to-cart.add-to-cart": "In den Warenkorb legen",
+  "store/add-to-cart.label-unavailable": "Nicht verfügbar",
+  "store/add-to-cart.select-sku-variations": "Bitte wählen Sie für jede Variante eine Option aus",
+  "admin/editor.add-to-cart.title": "In den Warenkorb legen",
+  "admin/editor.add-to-cart.text.title": "Text der Schaltfläche",
+  "admin/editor.add-to-cart.text.description": "Text der Schaltfläche, z. B. \"In den Warenkorb\"",
+  "admin/editor.add-to-cart.text-unavailable.title": "Schaltflächentext nicht verfügbar",
+  "admin/editor.add-to-cart.text-unavailable.description": "Schaltflächentext, wenn das Produkt nicht verfügbar ist."
+}


### PR DESCRIPTION
#### What problem is this solving?

This is part of a series of PRs in several apps to make German available accross the Admin. Tracked in task [LOC-9843](https://vtex-dev.atlassian.net/browse/LOC-9843).

#### How to test it?

A test store with DE in the language switcher is [available here](https://localizationqa--obidev.myvtex.com/admin/).

[LOC-9843]: https://vtex-dev.atlassian.net/browse/LOC-9843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ