### PR TITLE
Fix: KI 743529 (assembly options)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Assembly option quantity selections are no longer ignored (solves KI 743529)
+
 ## [0.30.0] - 2023-03-28
 
 ### Added

--- a/react/__tests__/AddToCartButton.test.tsx
+++ b/react/__tests__/AddToCartButton.test.tsx
@@ -134,7 +134,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -154,7 +154,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -174,7 +174,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected={false}
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -198,7 +198,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -218,7 +218,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -251,7 +251,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -284,7 +284,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -360,7 +360,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected={false}
         productLink={mockProductLink}
         onClickBehavior="add-to-cart"
@@ -390,7 +390,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="go-to-product-page"
@@ -427,7 +427,7 @@ describe('AddToCartButton component', () => {
         disabled={false}
         skuItems={mockSKUItems}
         customToastUrl=""
-        showToast={() => { }}
+        showToast={() => {}}
         allSkuVariationsSelected
         productLink={mockProductLink}
         onClickBehavior="ensure-sku-selection"

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -90,7 +90,7 @@ describe('assemblyOptions module', () => {
         parentQuantity,
       })
 
-      expect(resultBell.options).toHaveLength(5)
+      expect(resultBell.options).toHaveLength(7)
       const addonOption = resultBell.options[0] as ItemOption
       expect(addonOption.assemblyId).toBe('add-on_Add-on')
       expect(addonOption.id).toBe('2000588')
@@ -169,7 +169,7 @@ describe('assemblyOptions module', () => {
         parentQuantity,
       })
 
-      expect(resultBell.options).toHaveLength(5)
+      expect(resultBell.options).toHaveLength(7)
 
       const engraving = resultBell.options[4] as ItemOption
       expect(engraving.options).toHaveLength(1)

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -110,7 +110,7 @@ describe('assemblyOptions module', () => {
       expect(pizzaOption.id).toBe('5101')
       expect(pizzaOption.quantity).toBe(1)
       expect(pizzaOption.seller).toBe('1')
-      expect(pizzaOption.options).toHaveLength(3)
+      expect(pizzaOption.options).toHaveLength(9)
 
       const drinksOptions = resultPizza.options[1] as ItemOption
       expect(drinksOptions.options).toBeUndefined()
@@ -254,6 +254,12 @@ describe('assemblyOptions module', () => {
               "seller": "1",
             },
             Object {
+              "assemblyId": "add-on_Add-on",
+              "id": "2000590",
+              "quantity": 0,
+              "seller": "1"
+            },
+            Object {
               "assemblyId": "text_style_Text Style",
               "id": "2000591",
               "quantity": 0,
@@ -279,6 +285,12 @@ describe('assemblyOptions module', () => {
                 },
               ],
               "quantity": 1,
+              "seller": "1",
+            },
+            Object {
+              "assemblyId": "engraving_Engraving",
+              "id": "2000587",
+              "quantity": 0,
               "seller": "1",
             },
           ],

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -104,7 +104,7 @@ describe('assemblyOptions module', () => {
         parentQuantity,
       })
 
-      expect(resultPizza.options).toHaveLength(2)
+      expect(resultPizza.options).toHaveLength(4)
       const pizzaOption = resultPizza.options[0] as ItemOption
       expect(pizzaOption.assemblyId).toBe('pizza_composition_Pizza flavor')
       expect(pizzaOption.id).toBe('5101')
@@ -171,7 +171,7 @@ describe('assemblyOptions module', () => {
 
       expect(resultBell.options).toHaveLength(7)
 
-      const engraving = resultBell.options[4] as ItemOption
+      const engraving = resultBell.options[5] as ItemOption
       expect(engraving.options).toHaveLength(1)
 
       const recursiveInputValue = engraving.options![0] as ItemOption

--- a/react/__tests__/modules.test.ts
+++ b/react/__tests__/modules.test.ts
@@ -257,7 +257,7 @@ describe('assemblyOptions module', () => {
               "assemblyId": "add-on_Add-on",
               "id": "2000590",
               "quantity": 0,
-              "seller": "1"
+              "seller": "1",
             },
             Object {
               "assemblyId": "text_style_Text Style",

--- a/react/modules/assemblyOptions.ts
+++ b/react/modules/assemblyOptions.ts
@@ -158,21 +158,17 @@ export function transformAssemblyOptions({
         })
       }
 
-      const addedChildrenCount = childrenAddedData
-        ? childrenAddedData.options.length
-        : 0
-
-      if (quantity !== initialQuantity || addedChildrenCount > 0) {
-        options.push({
-          assemblyId: groupId,
-          id: item.id,
-          quantity: quantity * parentQuantity,
-          seller: item.seller,
-          ...(childrenOptions && childrenOptions.length > 0
-            ? { options: childrenOptions }
-            : {}),
-        })
-      }
+      // push all items to options array regardless of quantity
+      // this solves KI 743529
+      options.push({
+        assemblyId: groupId,
+        id: item.id,
+        quantity: quantity * parentQuantity,
+        seller: item.seller,
+        ...(childrenOptions && childrenOptions.length > 0
+          ? { options: childrenOptions }
+          : {}),
+      })
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Fixes this KI: https://vtexhelp.zendesk.com/agent/tickets/743529

Previously, assembly option group quantity selections were being ignored unless all group items were changed from their default quantities. This happens because the assembly options API will throw an error if the array length does not match the number of items in the group. 

To fix the problem, the `options` array is now populated with all items in the group, regardless of whether their quantity has been changed, or even if the quantity has been set to zero. 

#### How to test it?

Linked here: https://phdro--b2bstoreqa.myvtex.com/axe-package/p

1. Contact me (`arthur` on Slack) for login credentials.
2. Click "Add Components"
3. Change the quantity of the first item to 0 and the fourth item to 5.
4. Click "Add To Cart"
5. Note the correct items and quantity are added.