### PR TITLE
Fix: Add listPrice to item object sent to Pixel Event

### DIFF
--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -88,6 +88,7 @@ const mapSkuItemForPixelEvent = (skuItem: CartItem) => {
     ean: skuItem.ean,
     variant: skuItem.variant,
     price: skuItem.price,
+    listPrice: skuItem.listPrice,
     sellingPrice: skuItem.sellingPrice,
     priceIsInt: true,
     name: skuItem.name,


### PR DESCRIPTION
#### What problem is this solving?

This PR adds `sellingPrice` to the object sent to pixel events. The `listPrice` value represent the full price of the product to calculate the discount amount.

#### How to test it?

Capture an `vtex:addToCart` event from a pixel app with this new version linked. The `listPrice` value will be presented, as shown below.

![image](https://user-images.githubusercontent.com/31279648/236906093-cf9d4356-e045-40d4-9f48-3195c24e5652.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/OfkGZ5H2H3f8Y/giphy.gif)
