### PR TITLE
Fix/add coupon when add itens on cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add marketing tags together with coupon when adding items to the cart
+
 ## [0.30.2] - 2023-07-13
 ### Fixed
 - Fixes of i18n on readme.md according to task LOC-10625.

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -134,7 +134,7 @@ function AddToCartButton(props: Props) {
   const { push } = usePixel()
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings
-  const { utmParams, utmiParams } = useMarketingSessionParams()
+  const { utmParams, utmiParams, couponParam } = useMarketingSessionParams()
   const [isFakeLoading, setFakeLoading] = useState(false)
   const translateMessage = (message: MessageDescriptor) =>
     intl.formatMessage(message)
@@ -200,7 +200,7 @@ function AddToCartButton(props: Props) {
     }
 
     const addItemsPromise = addItems(skuItems, {
-      marketingData: { ...utmParams, ...utmiParams },
+      marketingData: { ...utmParams, ...utmiParams, ...couponParam },
       ...options,
     })
 

--- a/react/hooks/useMarketingSessionParams.ts
+++ b/react/hooks/useMarketingSessionParams.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 type PublicSessionField =
   | 'utm_source'
@@ -22,6 +23,10 @@ interface UtmiParams {
   utmiCampaign?: string
   utmiPage?: string
   utmiPart?: string
+}
+
+interface CouponParam {
+  coupon?: string
 }
 
 interface SessionPromiseResponse {
@@ -77,8 +82,14 @@ const getSessionPromiseFromWindow = () => {
 }
 
 const useMarketingSessionParams = () => {
+  const { orderForm: { marketingData}} = useOrderForm()
   const [utmParams, setUtmParams] = useState<UtmParams>({})
   const [utmiParams, setUtmiParams] = useState<UtmiParams>({})
+  const [couponParam, setCouponParam] = useState<CouponParam>({})
+
+  useEffect(() => {
+    if(marketingData?.coupon?.length) setCouponParam({ coupon: marketingData.coupon })
+  }, [marketingData])
 
   useEffect(() => {
     getSessionPromiseFromWindow()
@@ -104,7 +115,7 @@ const useMarketingSessionParams = () => {
       })
   }, [])
 
-  return { utmParams, utmiParams }
+  return { utmParams, utmiParams, couponParam }
 }
 
 export default useMarketingSessionParams


### PR DESCRIPTION
#### What problem is this solving?

When I send coupon together marketing tags, the coupon doesn't persist on cart. 
Video problem: https://vimeo.com/805646428
I opened a issue and I receive this answer: 
<img width="739" alt="Screenshot 2023-11-16 at 15 32 58" src="https://github.com/vtex-apps/add-to-cart-button/assets/121642109/9cbfbe96-8de7-4409-9229-84cb74226caa">

So, I had the instruction to add coupon on marketing tags on app add-to-cart and I tried and it is working

#### How to test it?

- add these params on url: ?utm_source=teste&utm_campaign=testedupagency&cupom=testedupagency
- add a lot of products on your cart 
- test if the coupon persist 

[Workspace](https://addtocartmarketingdata--duxnutrition.myvtex.com/)

#### Screenshots or example usage:
https://drive.google.com/file/d/1iyaNjKtsszFCk_dKzuKbemQaiCCqauXj/view?usp=sharing

#### Describe alternatives you've considered, if any.


#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](https://giphy.com/gifs/Zxzr2pp6qU64g)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![Anxious](https://media.giphy.com/media/Zxzr2pp6qU64g/giphy.gif)