### PR TITLE
Fix: root-level inputValues lost due to inverted filter in transformAssemblyOptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,6 @@
     }
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+VTEX IO Store Framework React component (`vtex.add-to-cart-button`) that adds products to Minicart v2. Handles add-to-cart interactions with support for one-click buy, SKU selection validation, assembly options (product customizations), and shipping modal triggers.
+
+## Commands
+
+```bash
+yarn lint              # ESLint on TS/TSX files (auto-fixes)
+yarn format            # Prettier on TS/JSON
+yarn test              # Runs tests in react/ directory (vtex-test-tools)
+yarn verify            # Pre-push: lint + locale check + test
+yarn lint:locales      # Validates i18n keys match across 28+ locales
+yarn locales:fix       # Auto-fixes i18n inconsistencies
+```
+
+Tests use `@vtex/test-tools/react` (React Testing Library wrapper). Mocks live in `react/__mocks__/`, fixtures in `react/__fixtures__/`.
+
+## Architecture
+
+```
+Wrapper.tsx (entry point, withToast HOC, connects to VTEX product context)
+  └─ AddToCartButton.tsx (button logic, click behaviors, pixel events, navigation)
+      ├─ modules/catalogItemToCart.ts (transforms product context → cart items)
+      ├─ modules/assemblyOptions.ts (recursive assembly/customization processing)
+      └─ hooks/useMarketingSessionParams.ts (UTM/UTMI from session)
+```
+
+**Wrapper.tsx**: Entry point wrapped with `withToast`. Uses `useProduct()` to get product data, determines availability/disabled state, memoizes cart item mapping via `catalogItemToCart`.
+
+**AddToCartButton.tsx**: Supports 4 click behaviors: `add-to-cart`, `go-to-product-page`, `ensure-sku-selection`, `add-to-cart-and-trigger-shipping-modal`. Tracks pixel events via `usePixel()`, handles one-click buy navigation, PWA install prompts.
+
+**catalogItemToCart.ts**: Maps VTEX product context to `CartItem[]`. Prices are **integers in cents** (multiply by 100). Uses `getDefaultSeller()` fallback (finds `sellerDefault=true` or first seller).
+
+**assemblyOptions.ts**: Recursively processes nested product customizations. `sumAssembliesPrice()` calculates total assembly cost. `transformAssemblyOptions()` builds options array for GraphQL mutation + added/removed metadata for optimistic UI. All items pushed to options regardless of quantity (KI 743529 fix).
+
+## Key VTEX Dependencies
+
+| Dependency | Hook/HOC | Purpose |
+|---|---|---|
+| vtex.product-context | `useProduct()`, `useProductDispatch()` | Product data, SKU selection |
+| vtex.order-items | `useOrderItems()` | `addItems()` cart mutation |
+| vtex.pixel-manager | `usePixel()` | Analytics (addToCart events) |
+| vtex.styleguide | `withToast`, Button, Tooltip | UI components, notifications |
+| vtex.render-runtime | `useRuntime()` | Navigation, route info |
+| vtex.checkout-resources | `Utils.useCheckoutURL()` | Checkout URL (v1/v2) |
+| vtex.shipping-option-components | `useShippingOptionState()` | Shipping modal trigger |
+| vtex.css-handles | `useCssHandles()` | CSS customization hooks |
+
+## Critical Patterns
+
+- **Empty Context Guard**: Always check `isEmptyContext` before accessing product data — component can render outside product context
+- **Prices as Cents**: All prices multiplied by 100 when mapping to cart items (integers, never decimals)
+- **Fake Loading**: 500ms for normal add-to-cart, 5s for one-click buy to prevent double-clicks
+- **Event Propagation**: Default `onClickEventPropagation='disabled'`
+- **One-Click Navigation**: `navigate()` for major>0 checkouts, `window.location.assign()` for legacy
+- **Marketing Session**: UTM/UTMI params from `window.__RENDER_8_SESSION__.sessionPromise` (async)
+- **Seller Fallback**: `getDefaultSeller()` finds `sellerDefault=true` or falls back to first seller
+
+## Store Builder
+
+- `store/interfaces.json` registers the `add-to-cart-button` block pointing to Wrapper
+- `store/contentSchemas.json` defines Site Editor props (`text`, `unavailableText`)
+- VTEX IO builders: react 3.x, store 0.x, messages 1.x, docs 0.x
+
+## i18n
+
+- 28+ locales in `messages/`, reference locale: `en`
+- Uses `react-intl`: `useIntl()` for hooks, `<FormattedMessage>` for JSX
+- Message IDs prefixed with `store/add-to-cart.*` (storefront) and `admin/editor.*` (Site Editor)
+- Pre-commit hook auto-runs `yarn locales:fix`
+
+## CI/CD
+
+GitHub Actions on PR to master: Danger CI, IO app test (`vtex/action-io-app-test`), Lint (`vtex/action-lint`). VTEX IO deployment handled separately.

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "vtex",
+  "vendor": "b2cqbano",
   "name": "add-to-cart-button",
   "version": "0.31.0",
   "title": "Add to Cart Button",

--- a/react/modules/assemblyOptions.ts
+++ b/react/modules/assemblyOptions.ts
@@ -108,10 +108,6 @@ export function transformAssemblyOptions({
         for (const key in item.children) {
           childInputValues[key] = inputValues[key]
         }
-        const handledInputValues = Object.keys(childInputValues)
-        assemblyInputValuesKeys = assemblyInputValuesKeys.filter(
-          inputValueKey => handledInputValues.includes(inputValueKey)
-        )
 
         childrenAddedData = transformAssemblyOptions({
           assemblyOptionsItems: item.children,

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,7 @@
   "add-to-cart-button": {
     "component": "Wrapper",
     "content": {
-      "$ref": "app:vtex.add-to-cart-button#/definitions/AddToCardButton"
+      "$ref": "app:b2cqbano.add-to-cart-button#/definitions/AddToCardButton"
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

  The transformAssemblyOptions function in assemblyOptions.ts contains an inverted filter that causes all root-level inputValues to 
  be lost when any assembly item has children.

  The filter at line 132 uses includes instead of !includes:

  // Bug: keeps ONLY child-handled keys, discards everything else
  assemblyInputValuesKeys = assemblyInputValuesKeys.filter(
    inputValueKey => handledInputValues.includes(inputValueKey)
  )

  After multiple iterations (one per item with children), assemblyInputValuesKeys becomes an empty array. This means the final loop 
  that processes root-level inputValues into the options[] array has nothing to iterate — no root-level inputValues are ever sent to
   the addItems GraphQL mutation.

  This affects any product where:
  1. Assembly items have children (nested assemblies)
  2. The root product has inputValues (e.g., attachments with text/boolean inputs)

  The fix removes the filter entirely because:
  - Children already receive their scoped inputValues independently through the recursive transformAssemblyOptions call (line 136)  
  - Root-level inputValues should always be processed at the root level
  - The flat inputValues dict from product-context means shared keys carry the same value, so there is no duplication risk between  
  levels

  #### How to test it?

  1. Configure a product with nested assembly options where the root SKU has an attachment with inputValues (e.g., a combo with a   
  text-based attachment at the root level and child items that also declare that same attachment group)
  2. Add the product to cart
  3. Open browser console and inspect the options[] array in the addItems mutation payload
  4. Before fix: root-level inputValues are missing from the options array
  5. After fix: root-level inputValues appear as { assemblyId: "GroupName", inputValues: {...} } in the root options array

  Debug tip: Add console.log before the return statement in transformAssemblyOptions to inspect the final options array and verify  
  root-level inputValues are present.

  [Workspace](Link goes here!)

  #### Screenshots or example usage:

  Before (bug): assemblyInputValuesKeys is empty after the items loop — no root inputValues sent:
  {"assemblyInputValuesKeys": [], "inputValues": {"GroupName": {"key": "value"}}}

  After (fix): assemblyInputValuesKeys preserves all root keys — inputValues correctly sent:
  {"assemblyInputValuesKeys": ["GroupName", "OtherGroup"], "inputValues": {"GroupName": {"key": "value"}}}

  #### Describe alternatives you've considered, if any.

  - Inverting the filter to !includes: This fixes the direction but still incorrectly removes root-level inputValues when a child   
  shares the same group name. Since children get their inputValues independently through recursion, the filter serves no purpose.   

  #### Related to / Depends on

  Related to KI 743529 fix (commit 7da4a06) which addressed assembly options being missing from the options array. This bug is in   
  the same function but affects the inputValues path rather than the composition items path.