### PR TITLE
chore(catalog): set platform-flow-id Shopper#2 (STR-969)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/add-to-cart-button
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#2
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: IRYIL8GG
 spec:


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` for this component, following the **Platform Flows** taxonomy (Dark Kitchen DK IDs).

## Change

- **`vtex.com/platform-flow-id`:** `Shopper#2`

Per **Platform Flows**, **Shopper#2** maps to **Navigation & Discovery → Cart Management** (managing the shopping cart: add/replace/remove items, coupons, purchase simulations).

## Classification rationale

The **add-to-cart-button** block adds products to the **Minicart** (`minicart.v2`) and operates in the storefront **before checkout**, which aligns with **Cart Management** rather than **Checkout** (**Shopper#4**, Purchase) or **Search, PLP & PDP** (**Shopper#1**).

This classification is consistent with the internal analysis that combined:

- Repository **README** / documentation (Minicart / OrderForm context)
- **Store Framework Navigator** skill (UI block executed in the `render-runtime` context on the shopper-facing path)
- **Platform Flows** document definitions for DK IDs

## Note on multiple flows

This component was assigned a **single** primary DK ID. When more than one flow applies, the convention is to list DK IDs separated by commas (no spaces), e.g. `CommDev#1,Merch#3`.

---

**Reviewers:** @vmourac-vtex @iago1501
