### PR TITLE
chore(catalog): set platform-flow-id Shopper#2 (STR-969)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/add-to-cart-button
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#2
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: IRYIL8GG
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Register `vtex.com/platform-flow-id` as `Shopper#2` in `.vtex/catalog-info.yaml` ([STR-969](https://vtex-dev.atlassian.net/browse/STR-969)).
+
 ## [0.31.0] - 2025-09-08
 
 ### Added


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Registers the **Platform Flow** Dark Kitchen identifier in Backstage by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml`.

## Change

| Annotation | Value |
|------------|--------|
| `vtex.com/platform-flow-id` | `Shopper#2` |

**Convention:** when multiple flows apply, list DK IDs separated by commas **without spaces** (e.g. `CommDev#1,Merch#3`). This component maps to a **single** flow.

## Classification (Platform Flows)

- **DK ID:** `Shopper#2`
- **Major flow:** Navigation & Discovery
- **Sub flow:** Cart Management — managing the shopping cart (add/replace/remove items, coupons, purchase simulations), before checkout.

## Rationale

The **add-to-cart-button** block adds products to the **Minicart** (`minicart.v2`) on the storefront. That matches **Cart Management** (**Shopper#2**), not **Search, PLP & PDP** (**Shopper#1**) nor **Checkout** (**Shopper#4**, Purchase).

This aligns with the catalog classification that combined:

- **README** / product docs (Minicart integration)
- **Store Framework Navigator** (storefront UI block under `render-runtime`, shopper path)
- **Platform Flows** PDF (DK ID definitions)

---

Reviewers: @vmourac-vtex @iago1501
